### PR TITLE
HTTPLogger 구현 & HTTPClient Test 작성

### DIFF
--- a/Dependencies.swift
+++ b/Dependencies.swift
@@ -3,7 +3,8 @@ import ProjectDescription
 let dependencies = Dependencies(
     swiftPackageManager: [
         .remote(url: "https://github.com/SnapKit/SnapKit.git", requirement: .upToNextMajor(from: "5.7.0")),
-        .remote(url: "https://github.com/Swinject/Swinject.git", requirement: .upToNextMajor(from: "2.8.0"))
+        .remote(url: "https://github.com/Swinject/Swinject.git", requirement: .upToNextMajor(from: "2.8.0")),
+        .remote(url: "https://github.com/apple/swift-log.git", requirement: .upToNextMajor(from: "1.5.0"))
     ],
     platforms: [.iOS]
 )

--- a/FoodDiary/Data/Project.swift
+++ b/FoodDiary/Data/Project.swift
@@ -21,6 +21,7 @@ let project = Project(
             dependencies: [
                 .project(target: "Domain", path: "../Domain"),
                 .external(name: "TensorFlowLiteSwift"),
+                .external(name: "Logging"),
             ]
         ),
         .target(

--- a/FoodDiary/Data/Sources/Network/HTTPClient.swift
+++ b/FoodDiary/Data/Sources/Network/HTTPClient.swift
@@ -10,22 +10,50 @@ import Foundation
 public struct HTTPClient: HTTPClienting {
     private let session: URLSession
     private let decoder: JSONDecoder
+    private let logger: HTTPLogger
     
-    public init(session: URLSession = .shared, decoder: JSONDecoder = .init()) {
+    public init(
+        session: URLSession = .shared,
+        decoder: JSONDecoder = .init(),
+        logger: HTTPLogger = HTTPLogger()
+    ) {
         self.session = session
         self.decoder = decoder
+        self.logger = logger
     }
-    
+
     public func request<T: Decodable>(_ request: some Requestable, accessToken: String? = nil) async throws -> T {
-        var urlRequest = try request.makeURLRequest()
-        applyAccessToken(accessToken, to: &urlRequest)
-        let (data, response) = try await session.data(for: urlRequest)
-        try checkResponse(data, response)
-        
         do {
-            return try decoder.decode(T.self, from: data)
+            var urlRequest = try request.makeURLRequest()
+            applyAccessToken(accessToken, to: &urlRequest)
+
+            logger.logRequest(urlRequest)
+
+            let (data, response) = try await session.data(for: urlRequest)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                logger.logError(NetworkError.invalidResponse, context: "Network error")
+                throw NetworkError.invalidResponse
+            }
+
+            logger.logResponse(response, statusCode: httpResponse.statusCode)
+
+            try checkResponse(data, httpResponse)
+
+            do {
+                let model = try decoder.decode(T.self, from: data)
+                logger.logDecodedModel(model)
+                return model
+            } catch {
+                logger.logError(error, context: "Decoding error")
+                throw NetworkError.decodingError
+            }
+        } catch let error as NetworkError {
+            logger.logError(error, context: "Network error")
+            throw error
         } catch {
-            throw NetworkError.decodingError
+            logger.logError(error, context: "Request error")
+            throw NetworkError.requestFailed
         }
     }
 }
@@ -36,18 +64,13 @@ private extension HTTPClient {
         guard let accessToken else { return }
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
     }
-    
-    func checkResponse(_ data: Data, _ response: URLResponse) throws {
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw NetworkError.invalidResponse
-        }
-        
-        // TODO: 네트워크 에러 핸들링 정의되고 나서 로직 재구현 예정.
-        switch httpResponse.statusCode {
+
+    func checkResponse(_ data: Data, _ response: HTTPURLResponse) throws {
+        switch response.statusCode {
         case 200..<300:
             return
         default:
-            throw NetworkError.httpError(statusCode: httpResponse.statusCode, data: data)
+            throw NetworkError.httpError(statusCode: response.statusCode, data: data)
         }
     }
 }

--- a/FoodDiary/Data/Sources/Network/HTTPLogger.swift
+++ b/FoodDiary/Data/Sources/Network/HTTPLogger.swift
@@ -1,0 +1,46 @@
+//
+//  HTTPLogger.swift
+//  Data
+//
+
+import Foundation
+import Logging
+
+public struct HTTPLogger {
+    private let logger: Logger
+
+    public init(logger: Logger = Logger(label: "com.fooddiary.network")) {
+        self.logger = logger
+    }
+
+    func logRequest(_ request: URLRequest) {
+        #if DEBUG
+        let method = request.httpMethod ?? "UNKNOWN"
+        let url = request.url?.absoluteString ?? "nil"
+        logger.info("[Request] [\(method)] \(url)")
+        #endif
+    }
+
+    func logResponse(_ response: URLResponse, statusCode: Int) {
+        #if DEBUG
+        let url = response.url?.absoluteString ?? "nil"
+        if (200..<300).contains(statusCode) {
+            logger.info("[Response] [\(statusCode)] \(url)")
+        } else {
+            logger.error("[Response] [\(statusCode)] \(url)")
+        }
+        #endif
+    }
+
+    func logDecodedModel<T>(_ model: T) {
+        #if DEBUG
+        logger.info("[Decoded] \(String(describing: type(of: model))): \(model)")
+        #endif
+    }
+
+    func logError(_ error: Error, context: String) {
+        #if DEBUG
+        logger.error("[Error] \(context): \(error.localizedDescription)")
+        #endif
+    }
+}

--- a/FoodDiary/Data/Sources/Network/NetworkError.swift
+++ b/FoodDiary/Data/Sources/Network/NetworkError.swift
@@ -9,8 +9,10 @@ import Foundation
 
 public enum NetworkError: Error {
     case invalidURL
+    case requestFailed
     case encodingError
     case decodingError
     case invalidResponse
     case httpError(statusCode: Int, data: Data?)
+    case unknown
 }

--- a/FoodDiary/Data/Tests/HTTPClientTests.swift
+++ b/FoodDiary/Data/Tests/HTTPClientTests.swift
@@ -1,0 +1,159 @@
+//
+//  HTTPClientTests.swift
+//  DataTests
+//
+
+import Foundation
+import Testing
+@testable import Data
+
+struct HTTPClientTests {
+    @Test("Request 성공 시 디코딩된 모델을 반환한다")
+    func request_whenSuccess_returnsDecodedModel() async throws {
+        let expectedResponse = MockResponseDTO(id: "123", message: "success")
+        let jsonData = try JSONEncoder().encode(expectedResponse)
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            
+            return (response, jsonData)
+        }
+
+        let session = MockURLProtocol.makeSession()
+        let sut = HTTPClient(session: session)
+
+        let result: MockResponseDTO = try await sut.request(MockEndpoint.minimal)
+
+        #expect(result == expectedResponse)
+    }
+
+    @Test("makeURLRequest 실패 시 NetworkError.invalidURL을 던진다")
+    func request_whenInvalidURL_throwsInvalidURLError() async throws {
+        let session = MockURLProtocol.makeSession()
+        let sut = HTTPClient(session: session)
+        
+        let error = await #expect(throws: NetworkError.self) {
+            struct InvalidEndpoint: Requestable {
+                var baseURL: String { "" }
+                var path: String { "" }
+                var httpMethod: HTTPMethod { .get }
+                var queryParameters: Encodable? { nil }
+                var bodyParameters: Encodable? { nil }
+                var headers: [String: String] { [:] }
+            }
+            
+            let _: MockResponseDTO = try await sut.request(InvalidEndpoint())
+        }
+
+        guard case .invalidURL = error else {
+            Issue.record("NetworkError.invalidURL을 예상했지만 \(String(describing: error))가 발생함")
+            return
+        }
+    }
+
+    @Test("session.data(for:) 실패 시 NetworkError.requestFailed로 처리된다")
+    func request_whenSessionFails_throwsUnknownError() async throws {
+        MockURLProtocol.requestHandler = { _ in
+            throw NSError(
+                domain: NSURLErrorDomain,
+                code: NSURLErrorNotConnectedToInternet,
+                userInfo: [NSLocalizedDescriptionKey: "The internet connection appears to be offline."]
+            )
+        }
+
+        let session = MockURLProtocol.makeSession()
+        let sut = HTTPClient(session: session)
+
+        let error = await #expect(throws: NetworkError.self) {
+            let _: MockResponseDTO = try await sut.request(MockEndpoint.minimal)
+        }
+        
+        guard case .requestFailed = error else {
+            Issue.record("NetworkError.requestFailed를 예상했지만 \(String(describing: error))가 발생함")
+            return
+        }
+    }
+    
+    @Test("Response를 HTTPURLResponse로 다운캐스팅 실패 시 NetworkError.invalidResponse로 처리된다")
+    func request_whenInvalidResponse_throwsInvalidResponseError() async throws {
+        MockURLProtocol.requestHandler = { request in
+            let response = URLResponse(
+                url: request.url!,
+                mimeType: nil,
+                expectedContentLength: 5,
+                textEncodingName: nil
+            )
+            
+            return (response, Data())
+        }
+        
+        let session = MockURLProtocol.makeSession()
+        let sut = HTTPClient(session: session)
+        
+        let error = await #expect(throws: NetworkError.self) {
+            let _: MockResponseDTO = try await sut.request(MockEndpoint.minimal)
+        }
+        
+        guard case .invalidResponse = error else {
+            Issue.record("NetworkError.invalidResponse를 예상했지만 \(String(describing: error))가 발생함")
+            return
+        }
+    }
+    
+    @Test("Response가 200번대가 아닐 시 NetworkError.httpError로 처리된다")
+    func request_whenNon2xxStatusCode_throwsHttpError() async throws {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            
+            return (response, Data())
+        }
+        
+        let session = MockURLProtocol.makeSession()
+        let sut = HTTPClient(session: session)
+        
+        let error = await #expect(throws: NetworkError.self) {
+            let _: MockResponseDTO = try await sut.request(MockEndpoint.minimal)
+        }
+        
+        guard case .httpError = error else {
+            Issue.record("NetworkError.httpError를 예상했지만 \(String(describing: error))가 발생함")
+            return
+        }
+    }
+    
+    @Test("Decode 실패 시 NetworkError.decodingError로 처리된다")
+    func request_whenDecodingFails_throwsDecodingError() async throws {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            
+            return (response, Data())
+        }
+        
+        let session = MockURLProtocol.makeSession()
+        let sut = HTTPClient(session: session)
+        
+        let error = await #expect(throws: NetworkError.self) {
+            let _: MockResponseDTO = try await sut.request(MockEndpoint.minimal)
+        }
+        
+        guard case .decodingError = error else {
+            Issue.record("NetworkError.decodingError를 예상했지만 \(String(describing: error))가 발생함")
+            return
+        }
+    }
+}

--- a/FoodDiary/Data/Tests/Mock/MockBodyDTO.swift
+++ b/FoodDiary/Data/Tests/Mock/MockBodyDTO.swift
@@ -11,3 +11,8 @@ struct MockBodyDTO: Encodable {
     let name: String
     let age: Int
 }
+
+struct MockResponseDTO: Codable, Equatable {
+    let id: String
+    let message: String
+}

--- a/FoodDiary/Data/Tests/Mock/MockURLProtocol.swift
+++ b/FoodDiary/Data/Tests/Mock/MockURLProtocol.swift
@@ -1,0 +1,47 @@
+//
+//  MockURLProtocol.swift
+//  Data
+//
+
+import Foundation
+
+final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (URLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            fatalError("MockURLProtocol.requestHandler is not set")
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+extension MockURLProtocol {
+    static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    static func reset() {
+        requestHandler = nil
+    }
+}

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -15,5 +15,6 @@ let package = Package(
         .package(url: "https://github.com/SnapKit/SnapKit.git", from: "5.7.0"),
         .package(url: "https://github.com/tareksabry1337/TensorFlowLiteSwift.git", from: "2.14.0"),
         .package(url: "https://github.com/Swinject/Swinject.git", from: "2.10.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
     ]
 )


### PR DESCRIPTION
## ✏️ 변경 내용
- Logger Dependency 추가
- HTTPLogger 구현 및 연결
- HTTPClient 에러 분기 세분화
- HTTPClient 테스트

로그는 **DEBUG** 모드에서만 찍히도록 구현했습니다!

> info VS error 의 차이?
```swift
logger.info("요청 시작")   // 일반 정보 → 운영 상황 파악용
logger.error("디코딩 실패") // 오류 발생 → 문제 추적용
```

HTTPClient 테스트할 때 예전에는 URLSession 상속하고 FakeURLSession을 만들어서 테스트했었는데,
[다른 방법](https://linux-studying.tistory.com/31)도 있길래 이번에 적용해보면서 함께 공유합니다~

## ✅ 체크리스트
- [x] 빌드 정상 동작
- [x] 불필요한 파일 없음

## 요청사항
에러를 분기해두긴 했는데, 모호하거나 개선할 부분이 있다면 편하게 말해주세용🙏