### PR TITLE
마이페이지 뷰모델 리팩토링

### DIFF
--- a/FoodDiary/App/Sources/AppFlowController.swift
+++ b/FoodDiary/App/Sources/AppFlowController.swift
@@ -94,10 +94,25 @@ extension AppFlowController {
         let weeklyCalendarVC = makeWeeklyCalendarVC()
         let monthlyCalendarVC = makeMonthlyCalendarVC()
 
+        let myPageVCFactory: (@escaping () -> Void) -> UIViewController = { [container] onLogout in
+            guard let vm = try? container.resolve(MyPageViewModel.self) else {
+                fatalError("MyPageViewModel not registered")
+            }
+            let vc = MyPageViewController(viewModel: vm)
+            var cancellable: AnyCancellable?
+            cancellable = vc.didLogoutPublisher
+                .sink {
+                    onLogout()
+                    _ = cancellable
+                }
+            return vc
+        }
+
         let tabBarVC = RootTabBarController(
             weeklyVC: weeklyCalendarVC,
             monthlyVC: monthlyCalendarVC,
-            insightVC: InsightViewController()
+            insightVC: InsightViewController(),
+            myPageViewControllerFactory: myPageVCFactory
         )
 
         tabBarVC.didLogoutPublisher

--- a/FoodDiary/App/Sources/SceneDelegate.swift
+++ b/FoodDiary/App/Sources/SceneDelegate.swift
@@ -391,7 +391,7 @@ extension SceneDelegate {
         }
 
         container.register(
-            UpdateDeviceNotificationSettingUseCase<DeviceRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>.self
+            UpdateDeviceNotificationSettingUseCase.self
         ) { resolver in
             guard let repository = resolver.resolve(DeviceRepository.self),
                   let pushTokenProvider = resolver.resolve(PushTokenStoring.self),
@@ -608,7 +608,7 @@ extension SceneDelegate {
 
         container.register(MyPageViewModel.self, scope: .transient) { resolver in
             guard let updateDeviceUseCase = resolver.resolve(
-                UpdateDeviceNotificationSettingUseCase<DeviceRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>.self
+                UpdateDeviceNotificationSettingUseCase.self
             ),
                   let notificationAuthProvider = resolver.resolve(NotificationAuthorizationProviding.self),
                   let logoutUseCase = resolver.resolve(LogoutUseCase.self),

--- a/FoodDiary/Domain/Sources/UseCase/UpdateDeviceNotificationSettingUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/UpdateDeviceNotificationSettingUseCase.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-public struct UpdateDeviceNotificationSettingUseCase<Repository: DeviceRepository> {
-    private let repository: Repository
+public struct UpdateDeviceNotificationSettingUseCase {
+    private let repository: DeviceRepository
     private let notificationAuthorizationProvider: NotificationAuthorizationProviding
     private let pushTokenProvider: PushTokenStoring
     private let appVersion: String
@@ -16,7 +16,7 @@ public struct UpdateDeviceNotificationSettingUseCase<Repository: DeviceRepositor
     private let osVersion: String
 
     public init(
-        repository: Repository,
+        repository: DeviceRepository,
         notificationAuthorizationProvider: NotificationAuthorizationProviding,
         pushTokenProvider: PushTokenStoring,
         appVersion: String,

--- a/FoodDiary/Presentation/Sources/Calendar/CalendarViewController.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/CalendarViewController.swift
@@ -54,7 +54,7 @@ public final class CalendarViewController: UIViewController {
             currentChild.view.removeFromSuperview()
             currentChild.removeFromParent()
         }
-        
+
         addChild(targetVC)
         view.addSubview(targetVC.view)
         targetVC.view.snp.makeConstraints { $0.edges.equalToSuperview() }

--- a/FoodDiary/Presentation/Sources/MyPage/ViewModel/MyPageViewModel.swift
+++ b/FoodDiary/Presentation/Sources/MyPage/ViewModel/MyPageViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import Combine
-import Data
 import Domain
 import Foundation
 import UIKit
@@ -37,7 +36,7 @@ public final class MyPageViewModel {
     private let stateSubject: CurrentValueSubject<State, Never>
     private let eventSubject = PassthroughSubject<Event, Never>()
     private var cancellables = Set<AnyCancellable>()
-    private let updateDeviceNotificationSettingUseCase: UpdateDeviceNotificationSettingUseCase<DeviceRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>
+    private let updateDeviceNotificationSettingUseCase: UpdateDeviceNotificationSettingUseCase
     private let notificationAuthorizationProvider: NotificationAuthorizationProviding
     private let logoutUseCase: LogoutUseCase
     private let withdrawUserUseCase: WithdrawUserUseCase
@@ -45,7 +44,7 @@ public final class MyPageViewModel {
     // MARK: - Init
 
     public init(
-        updateDeviceNotificationSettingUseCase: UpdateDeviceNotificationSettingUseCase<DeviceRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>,
+        updateDeviceNotificationSettingUseCase: UpdateDeviceNotificationSettingUseCase,
         notificationAuthorizationProvider: NotificationAuthorizationProviding,
         logoutUseCase: LogoutUseCase,
         withdrawUserUseCase: WithdrawUserUseCase

--- a/FoodDiary/Presentation/Sources/TabBar/RootTabBarController.swift
+++ b/FoodDiary/Presentation/Sources/TabBar/RootTabBarController.swift
@@ -7,23 +7,28 @@
 
 import UIKit
 import DesignSystem
-import DI
 import Combine
 
 public final class RootTabBarController: UITabBarController {
     let calendarVC: CalendarViewController
-    let insightVC: InsightViewController
+    let insightVC: UIViewController
+    private let myPageViewControllerFactory: (@escaping () -> Void) -> UIViewController
     private let didLogoutSubject = PassthroughSubject<Void, Never>()
-    private var myPageCancellable: AnyCancellable?
     private var cancellables = Set<AnyCancellable>()
 
     public var didLogoutPublisher: AnyPublisher<Void, Never> {
         didLogoutSubject.eraseToAnyPublisher()
     }
 
-    public init(weeklyVC: UIViewController, monthlyVC: UIViewController, insightVC: InsightViewController) {
+    public init(
+        weeklyVC: UIViewController,
+        monthlyVC: UIViewController,
+        insightVC: UIViewController,
+        myPageViewControllerFactory: @escaping (@escaping () -> Void) -> UIViewController
+    ) {
         self.calendarVC = CalendarViewController(weeklyVC: weeklyVC, monthlyVC: monthlyVC)
         self.insightVC = insightVC
+        self.myPageViewControllerFactory = myPageViewControllerFactory
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -78,18 +83,10 @@ public final class RootTabBarController: UITabBarController {
     }
 
     @objc private func mypageButtonTapped() {
-        guard let myPageVM = try? DIContainer.shared.resolve(MyPageViewModel.self) else {
-            print("MyPageViewModel resolve 실패")
-            return
+        let myPageVC = myPageViewControllerFactory { [weak self] in
+            self?.didLogoutSubject.send()
         }
-
-        let myPageVC = MyPageViewController(viewModel: myPageVM)
-
-        myPageCancellable = myPageVC.didLogoutPublisher
-            .sink { [weak self] in
-                self?.didLogoutSubject.send()
-            }
-
+        myPageVC.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(myPageVC, animated: true)
     }
     


### PR DESCRIPTION
## ✏️ 변경 내용
- MyPageViewModel Presentation -> Data 의존성 제거

UpdateDeviceNotificationSettingUseCase에서 제네릭으로 타입 고정할 때 Data모듈을 불가피하게 가져오게 되어 제네릭을 제거했습니다.

## ✅ 체크리스트
- [x] 빌드 정상 동작
- [x] 불필요한 파일 없음