### PR TITLE
DetailViewController 팩토리 통합

### DIFF
--- a/FoodDiary/App/Sources/AppFlowController.swift
+++ b/FoodDiary/App/Sources/AppFlowController.swift
@@ -183,85 +183,16 @@ extension AppFlowController {
             fatalError("WeeklyCalendarViewModel not registered")
         }
 
-        typealias DetailVM = DetailViewModel<
-            FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>,
-            PendingFoodRecordStorage<FileStorageService>,
-            PushNotificationObserver
-        >
-        typealias EditVM = EditFoodRecordViewModel<
-            FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-        >
-        typealias AddressSearchVM = AddressSearchViewModel<AddressSearchRepositoryImpl>
-
-        let addressSearchVCFactory:
-            (Int, @escaping (AddressSearchResult) -> Void) -> UIViewController = {
-                [container] diaryId, onSelect in
-                guard
-                    let addressVM = try? container.resolve(AddressSearchVM.self, argument: diaryId)
-                else {
-                    fatalError("AddressSearchViewModel not registered")
-                }
-                return AddressSearchViewController(
-                    viewModel: addressVM, onAddressSelected: onSelect)
-            }
-
-        let editVCFactory: (FoodRecord) -> UIViewController = { [weak self, container] record in
-            guard let self else { return UIViewController() }
-            guard let editVM = try? container.resolve(EditVM.self, argument: record) else {
-                fatalError("EditFoodRecordViewModel not registered")
-            }
-
-            let presentImagePickerHandler:
-                (UINavigationController, Date, @escaping ([any ImageAssetable], [UIImage]) -> Void)
-                    -> Void = { [weak self] nav, date, onSelected in
-                        guard let self else { return }
-                        self.presentImagePicker(
-                            from: nav,
-                            date: date,
-                            configuration: ImagePickerConfiguration.default,
-                            autoPreselectByProbability: false,
-                            loadPreviewImages: true,
-                            onSelected: { assets, previewImages in
-                                onSelected(assets, previewImages)
-                            }
-                        )
-                    }
-
-            return EditFoodRecordViewController(
-                viewModel: editVM,
-                addressSearchViewControllerFactory: addressSearchVCFactory,
-                presentImagePickerHandler: presentImagePickerHandler
-            )
-        }
-
-        let detailImagePickerHandler:
-            (UINavigationController, Date, @escaping ([any ImageAssetable]) -> Void)
-                -> Void = { [weak self] nav, date, onSelected in
-                    guard let self else { return }
-                    self.presentImagePicker(
-                        from: nav,
-                        date: date,
-                        configuration: .withMaxSelectionCount(10),
-                        autoPreselectByProbability: true,
-                        loadPreviewImages: false,
-                        onSelected: { assets, _ in
-                            onSelected(assets)
-                        }
-                    )
-                }
-
         return WeeklyCalendarViewController(
             viewModel: weeklyViewModel,
             imageProvider: imageProvider,
-            detailViewModelFactory: { [container] date, records in
-                guard let vm = try? container.resolve(DetailVM.self, argument: (date, records))
-                else {
-                    fatalError("DetailViewModel not registered")
-                }
-                return vm
-            },
-            editViewControllerFactory: editVCFactory,
-            presentImagePickerHandler: detailImagePickerHandler
+            detailViewControllerFactory: { [weak self] date, records, onDismiss in
+                self?.makeDetailViewController(
+                    date: date,
+                    records: records,
+                    onDismissWithDate: onDismiss
+                ) ?? UIViewController()
+            }
         )
     }
 
@@ -270,43 +201,19 @@ extension AppFlowController {
             FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>,
             PhotoAuthorizationFetcher
         >
-        typealias DetailVM = DetailViewModel<
-            FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>,
-            PendingFoodRecordStorage<FileStorageService>,
-            PushNotificationObserver
-        >
 
         guard let monthlyViewModel = try? container.resolve(MonthlyVM.self) else {
             fatalError("MonthlyCalendarViewModel not registered")
         }
 
-        let detailImagePickerHandler:
-            (UINavigationController, Date, @escaping ([any ImageAssetable]) -> Void)
-                -> Void = { [weak self] nav, date, onSelected in
-                    guard let self else { return }
-                    self.presentImagePicker(
-                        from: nav,
-                        date: date,
-                        configuration: .withMaxSelectionCount(10),
-                        autoPreselectByProbability: true,
-                        loadPreviewImages: false,
-                        onSelected: { assets, _ in
-                            onSelected(assets)
-                        }
-                    )
-                }
-
         return MonthlyCalendarViewController(
             viewModel: monthlyViewModel,
-            detailViewControllerFactory: { [container] date, records in
-                guard let detailVM = try? container.resolve(DetailVM.self, argument: (date, records))
-                else {
-                    fatalError("DetailViewModel not registered")
-                }
-                return DetailViewController(
-                    viewModel: detailVM,
-                    presentImagePickerHandler: detailImagePickerHandler
-                )
+            detailViewControllerFactory: { [weak self] date, records, onDismiss in
+                self?.makeDetailViewController(
+                    date: date,
+                    records: records,
+                    onDismissWithDate: onDismiss
+                ) ?? UIViewController()
             }
         )
     }
@@ -402,9 +309,101 @@ extension AppFlowController {
     }
 }
 
+// MARK: - Detail & Edit Factory
+
+extension AppFlowController {
+    private typealias DetailVM = DetailViewModel<
+        FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>,
+        PendingFoodRecordStorage<FileStorageService>,
+        PushNotificationObserver
+    >
+    private typealias EditVM = EditFoodRecordViewModel<
+        FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
+    >
+    private typealias AddressSearchVM = AddressSearchViewModel<AddressSearchRepositoryImpl>
+
+    fileprivate func makeDetailViewController(
+        date: Date,
+        records: [FoodRecord],
+        onDismissWithDate: ((Date) -> Void)? = nil
+    ) -> UIViewController {
+        guard let detailVM = try? container.resolve(DetailVM.self, argument: (date, records))
+        else {
+            fatalError("DetailViewModel not registered")
+        }
+
+        return DetailViewController(
+            viewModel: detailVM,
+            onDismissWithDate: onDismissWithDate,
+            editViewControllerFactory: { [weak self] record in
+                self?.makeEditViewController(for: record) ?? UIViewController()
+            },
+            presentImagePickerHandler: makeDetailImagePickerHandler()
+        )
+    }
+
+    fileprivate func makeEditViewController(for record: FoodRecord) -> UIViewController {
+        guard let editVM = try? container.resolve(EditVM.self, argument: record) else {
+            fatalError("EditFoodRecordViewModel not registered")
+        }
+
+        let addressSearchVCFactory:
+            (Int, @escaping (AddressSearchResult) -> Void) -> UIViewController = {
+                [container] diaryId, onSelect in
+                guard
+                    let addressVM = try? container.resolve(AddressSearchVM.self, argument: diaryId)
+                else {
+                    fatalError("AddressSearchViewModel not registered")
+                }
+                return AddressSearchViewController(
+                    viewModel: addressVM, onAddressSelected: onSelect)
+            }
+
+        let presentImagePickerHandler:
+            (UINavigationController, Date, @escaping ([any ImageAssetable], [UIImage]) -> Void)
+                -> Void = { [weak self] nav, date, onSelected in
+                    guard let self else { return }
+                    self.presentImagePicker(
+                        from: nav,
+                        date: date,
+                        configuration: ImagePickerConfiguration.default,
+                        autoPreselectByProbability: false,
+                        loadPreviewImages: true,
+                        onSelected: { assets, previewImages in
+                            onSelected(assets, previewImages)
+                        }
+                    )
+                }
+
+        return EditFoodRecordViewController(
+            viewModel: editVM,
+            addressSearchViewControllerFactory: addressSearchVCFactory,
+            presentImagePickerHandler: presentImagePickerHandler
+        )
+    }
+}
+
 // MARK: - Image Picker
 
 extension AppFlowController {
+    fileprivate func makeDetailImagePickerHandler()
+        -> (UINavigationController, Date, @escaping ([any ImageAssetable]) -> Void) -> Void
+    {
+        return { [weak self] nav, date, onSelected in
+            guard let self else { return }
+            self.presentImagePicker(
+                from: nav,
+                date: date,
+                configuration: .withMaxSelectionCount(10),
+                autoPreselectByProbability: true,
+                loadPreviewImages: false,
+                onSelected: { assets, _ in
+                    onSelected(assets)
+                }
+            )
+        }
+    }
+
     fileprivate func presentImagePicker(
         from nav: UINavigationController,
         date: Date,

--- a/FoodDiary/Presentation/Sources/Calendar/MonthlyCalendar/MonthlyCalendarViewController.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/MonthlyCalendar/MonthlyCalendarViewController.swift
@@ -21,7 +21,7 @@ public final class MonthlyCalendarViewController<
     // MARK: - Dependencies
 
     private let viewModel: MonthlyCalendarViewModel<RecordRepo, AuthRepo>
-    private let detailViewControllerFactory: ((Date, [FoodRecord]) -> UIViewController)
+    private let detailViewControllerFactory: ((Date, [FoodRecord], ((Date) -> Void)?) -> UIViewController)
 
     // MARK: - UI Components
 
@@ -69,7 +69,7 @@ public final class MonthlyCalendarViewController<
 
     public init(
         viewModel: MonthlyCalendarViewModel<RecordRepo, AuthRepo>,
-        detailViewControllerFactory: @escaping ((Date, [FoodRecord]) -> UIViewController)
+        detailViewControllerFactory: @escaping (Date, [FoodRecord], ((Date) -> Void)?) -> UIViewController
     ) {
         self.viewModel = viewModel
         self.detailViewControllerFactory = detailViewControllerFactory
@@ -93,11 +93,6 @@ public final class MonthlyCalendarViewController<
         collectionView.delegate = self
 
         viewModel.input.send(.loadInitialData)
-    }
-
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        viewModel.input.send(.refreshCurrentMonth)
     }
 
     public override func viewDidLayoutSubviews() {
@@ -300,7 +295,9 @@ public final class MonthlyCalendarViewController<
     // MARK: - Navigation
 
     private func navigateToDetail(date: Date, records: [FoodRecord]) {
-        let detailVC = detailViewControllerFactory(date, records)
+        let detailVC = detailViewControllerFactory(date, records) { [weak self] _ in
+            self?.viewModel.input.send(.refreshCurrentMonth)
+        }
         detailVC.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(detailVC, animated: true)
     }

--- a/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/WeeklyCalendarViewController.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/WeeklyCalendarViewController.swift
@@ -26,9 +26,7 @@ public final class WeeklyCalendarViewController<
             RecordRepo, AssetRepo, AuthRepo, PendingRepo, PushObserver
         >
     private let imageProvider: ImageProvider
-    private let detailViewModelFactory: (Date, [FoodRecord]) -> DetailViewModel<RecordRepo, PendingRepo, PushObserver>
-    private let editViewControllerFactory: ((FoodRecord) -> UIViewController)?
-    private let presentImagePickerHandler: ((UINavigationController, Date, @escaping ([any ImageAssetable]) -> Void) -> Void)?
+    private let detailViewControllerFactory: (Date, [FoodRecord], ((Date) -> Void)?) -> UIViewController
 
     // MARK: - UI Components
 
@@ -56,15 +54,11 @@ public final class WeeklyCalendarViewController<
             RecordRepo, AssetRepo, AuthRepo, PendingRepo, PushObserver
         >,
         imageProvider: ImageProvider,
-        detailViewModelFactory: @escaping (Date, [FoodRecord]) -> DetailViewModel<RecordRepo, PendingRepo, PushObserver>,
-        editViewControllerFactory: ((FoodRecord) -> UIViewController)? = nil,
-        presentImagePickerHandler: ((UINavigationController, Date, @escaping ([any ImageAssetable]) -> Void) -> Void)? = nil
+        detailViewControllerFactory: @escaping (Date, [FoodRecord], ((Date) -> Void)?) -> UIViewController
     ) {
         self.viewModel = viewModel
         self.imageProvider = imageProvider
-        self.detailViewModelFactory = detailViewModelFactory
-        self.editViewControllerFactory = editViewControllerFactory
-        self.presentImagePickerHandler = presentImagePickerHandler
+        self.detailViewControllerFactory = detailViewControllerFactory
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -354,16 +348,9 @@ public final class WeeklyCalendarViewController<
 
     private func navigateToDetail(for date: Date) {
         let records = viewModel.state.weekDays.records(for: date)
-
-        let detailViewModel = detailViewModelFactory(date, records)
-        let detailVC = DetailViewController(
-            viewModel: detailViewModel,
-            onDismissWithDate: { [weak self] date in
-                self?.viewModel.input.send(.refreshData(date))
-            },
-            editViewControllerFactory: editViewControllerFactory,
-            presentImagePickerHandler: presentImagePickerHandler
-        )
+        let detailVC = detailViewControllerFactory(date, records) { [weak self] date in
+            self?.viewModel.input.send(.refreshData(date))
+        }
         navigationController?.pushViewController(detailVC, animated: true)
     }
 }


### PR DESCRIPTION
## ✏️ 변경 내용
- Weekly/Monthly에서 중복되던 DetailViewController 팩토리를 `makeDetailViewController()`로 통합
- EditViewController, AddressSearchViewController 팩토리도 AppFlowController extension으로 분리
- MonthlyCalendarViewController의 `viewWillAppear` 제거 → `onDismissWithDate` 콜백으로 대체하여 불필요한 새로고침 최적화
- detailViewControllerFactory 시그니처 통일: `(Date, [FoodRecord], ((Date) -> Void)?) -> UIViewController`

-> 뭐 빼먹고 하는 대부분의 버그 수정됨

## ✅ 체크리스트
- [x] 빌드 정상 동작
- [x] 불필요한 파일 없음