### PR TITLE
refactor: 이미지 에셋 프리페치 개선

### DIFF
--- a/FoodDiary/App/Sources/AppFlowController.swift
+++ b/FoodDiary/App/Sources/AppFlowController.swift
@@ -257,10 +257,26 @@ extension AppFlowController {
                 let mainVC = createMainView()
                 transition(to: mainVC)
                 showCoachmarkOverlay(on: mainVC)
+                prefetchInitialFoodImageAssets()
             }
             .store(in: &cancellables)
 
         return UINavigationController(rootViewController: onboardingVC)
+    }
+
+    /// 온보딩 완료 후 사진 권한 획득 → 과거 4주치 FoodImageAsset prefetch
+    private func prefetchInitialFoodImageAssets() {
+        guard let authUseCase = try? container.resolve(AuthUseCase.self),
+              let fetchUseCase = try? container.resolve(FetchUseCase.self)
+        else { return }
+
+        Task {
+            if !authUseCase.isAuthorized() {
+                let status = await authUseCase.execute()
+                guard status == .authorized || status == .limited else { return }
+            }
+            fetchUseCase.prefetch(forPreviousWeeks: 4, of: Date())
+        }
     }
 
     fileprivate func showCoachmarkOverlay(on viewController: UIViewController) {

--- a/FoodDiary/App/Sources/AppFlowController.swift
+++ b/FoodDiary/App/Sources/AppFlowController.swift
@@ -257,14 +257,15 @@ extension AppFlowController {
                 let mainVC = createMainView()
                 transition(to: mainVC)
                 showCoachmarkOverlay(on: mainVC)
-                prefetchInitialFoodImageAssets()
             }
             .store(in: &cancellables)
+
+        prefetchInitialFoodImageAssets()
 
         return UINavigationController(rootViewController: onboardingVC)
     }
 
-    /// 온보딩 완료 후 사진 권한 획득 → 과거 4주치 FoodImageAsset prefetch
+    /// 온보딩 진입 시 사진 권한 획득 → 과거 4주치 FoodImageAsset prefetch
     private func prefetchInitialFoodImageAssets() {
         guard let authUseCase = try? container.resolve(AuthUseCase.self),
               let fetchUseCase = try? container.resolve(FetchUseCase.self)

--- a/FoodDiary/Data/Sources/Core/FoodImageAsset/FoodImageAssetFetcher.swift
+++ b/FoodDiary/Data/Sources/Core/FoodImageAsset/FoodImageAssetFetcher.swift
@@ -63,11 +63,8 @@ public struct FoodImageAssetFetcher<
         return result
     }
 
-    public func prefetchFoodImageAssets(forAdjacentWeeksOf date: Date) {
+    public func prefetchFoodImageAssets(forPreviousWeeks weekCount: Int, of date: Date) {
         let calendar = Calendar.current
-        guard let oneWeekAgo = calendar.date(byAdding: .weekOfYear, value: -1, to: date),
-              let twoWeeksAgo = calendar.date(byAdding: .weekOfYear, value: -2, to: date)
-        else { return }
 
         func weekRange(for targetDate: Date) -> (start: Date, end: Date)? {
             guard
@@ -79,18 +76,21 @@ public struct FoodImageAssetFetcher<
             return (startOfWeek, endOfWeek)
         }
 
-        guard let currentRange = weekRange(for: date) else { return }
-        let previousWeeks = [oneWeekAgo, twoWeeksAgo]
+        let previousDates = (1...weekCount).compactMap {
+            calendar.date(byAdding: .weekOfYear, value: -$0, to: date)
+        }
 
         Task(priority: .utility) {
             // 현재 주를 먼저 완료
-            _ = try? await self.fetchFoodImageAssets(
-                from: currentRange.start,
-                to: currentRange.end
-            )
+            if let currentRange = weekRange(for: date) {
+                _ = try? await self.fetchFoodImageAssets(
+                    from: currentRange.start,
+                    to: currentRange.end
+                )
+            }
 
-            // 이전 2주를 병렬로 백그라운드 실행
-            for targetDate in previousWeeks {
+            // 과거 주를 병렬로 백그라운드 실행
+            for targetDate in previousDates {
                 guard let range = weekRange(for: targetDate) else { continue }
                 Task(priority: .background) {
                     _ = try? await self.fetchFoodImageAssets(

--- a/FoodDiary/Data/Sources/Core/FoodImageAsset/FoodImageAssetFetcher.swift
+++ b/FoodDiary/Data/Sources/Core/FoodImageAsset/FoodImageAssetFetcher.swift
@@ -6,6 +6,7 @@
 //
 
 import Domain
+import Logging
 import Photos
 import UIKit
 
@@ -18,6 +19,7 @@ public struct FoodImageAssetFetcher<
     private let imageRepository: ImageRepo
     private let cache: ClassificationCacheManager
     private let imageTargetSize: CGSize
+    private let logger = Logger(label: "com.fooddiary.asset-fetcher")
 
     /// - Parameters:
     ///   - foodClassifier: 음식 분류기
@@ -42,11 +44,23 @@ public struct FoodImageAssetFetcher<
     ) async throws -> [Date: [FoodImageAsset<PHAsset>]] {
         let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
         guard status == .authorized || status == .limited else {
+            logger.error("[Asset Fetch] 사진 라이브러리 권한 없음 (status: \(status.rawValue))")
             throw FoodImageAssetError.notAuthorized
         }
 
+        logger.info("[Asset Fetch] 시작 (\(startDate) ~ \(endDate?.description ?? "nil"))")
+        let clock = ContinuousClock()
+        let start = clock.now
+
         let sections = await fetchPhotoSections(from: startDate, to: endDate)
-        return try await classifyAllSections(sections)
+        let totalPhotos = sections.reduce(0) { $0 + $1.assets.count }
+        logger.info("[Asset Fetch] 사진 \(totalPhotos)장 / \(sections.count)개 섹션 조회됨")
+
+        let result = try await classifyAllSections(sections)
+        let elapsed = clock.now - start
+        logger.info("[Asset Fetch] 완료 (소요: \(elapsed))")
+
+        return result
     }
 
     public func prefetchFoodImageAssets(forWeekContaining date: Date) {
@@ -126,7 +140,13 @@ extension FoodImageAssetFetcher {
     fileprivate func classifyPhotosInSection(_ section: PhotoSection) async throws
         -> [PHFoodImageAsset]
     {
-        try await withThrowingTaskGroup( 
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM/dd"
+        logger.info("[Classify] \(dateFormatter.string(from: section.date)) 섹션 \(section.assets.count)장 분류 시작")
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        return try await withThrowingTaskGroup(
             of: (originalIndex: Int, photo: PHFoodImageAsset).self
         ) { group in
             for (index, asset) in section.assets.enumerated() {
@@ -139,10 +159,14 @@ extension FoodImageAssetFetcher {
             for try await result in group {
                 results.append(result)
             }
-            return
-                results
+            let photos = results
                 .sorted { $0.originalIndex < $1.originalIndex }
                 .map(\.photo)
+
+            let elapsed = clock.now - start
+            let foodCount = photos.filter { $0.foodProbability > 0.5 }.count
+            logger.info("[Classify] \(dateFormatter.string(from: section.date)) 섹션 완료 - 음식 \(foodCount)/\(photos.count)장 (소요: \(elapsed))")
+            return photos
         }
     }
 
@@ -150,18 +174,21 @@ extension FoodImageAssetFetcher {
         let identifier = asset.localIdentifier
 
         if let cached = await cache.get(identifier) {
+            logger.trace("[Classify] 캐시 히트 \(identifier) (prob: \(cached.foodProbability))")
             return FoodImageAsset(
                 imageAsset: asset,
                 foodProbability: cached.foodProbability
             )
         }
 
+        logger.trace("[Classify] 캐시 미스 \(identifier)")
         let image = try await imageRepository.loadImage(
             for: asset,
             targetSize: imageTargetSize,
             preferFastDelivery: true
         )
         let result = try foodClassifier.classify(image: image)
+        logger.trace("[Classify] 분류 완료 \(identifier) (prob: \(result.foodProbability))")
 
         await cache.set(
             .init(

--- a/FoodDiary/Data/Sources/Core/FoodImageAsset/FoodImageAssetFetcher.swift
+++ b/FoodDiary/Data/Sources/Core/FoodImageAsset/FoodImageAssetFetcher.swift
@@ -63,19 +63,42 @@ public struct FoodImageAssetFetcher<
         return result
     }
 
-    public func prefetchFoodImageAssets(forWeekContaining date: Date) {
+    public func prefetchFoodImageAssets(forAdjacentWeeksOf date: Date) {
         let calendar = Calendar.current
-        guard
-            let startOfWeek = calendar.date(
-                from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)
-            ),
-            let endOfWeek = calendar.date(byAdding: .day, value: 7, to: startOfWeek)
-        else {
-            return
+        guard let oneWeekAgo = calendar.date(byAdding: .weekOfYear, value: -1, to: date),
+              let twoWeeksAgo = calendar.date(byAdding: .weekOfYear, value: -2, to: date)
+        else { return }
+
+        func weekRange(for targetDate: Date) -> (start: Date, end: Date)? {
+            guard
+                let startOfWeek = calendar.date(
+                    from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: targetDate)
+                ),
+                let endOfWeek = calendar.date(byAdding: .day, value: 7, to: startOfWeek)
+            else { return nil }
+            return (startOfWeek, endOfWeek)
         }
 
-        Task(priority: .background) {
-            _ = try? await self.fetchFoodImageAssets(from: startOfWeek, to: endOfWeek)
+        guard let currentRange = weekRange(for: date) else { return }
+        let previousWeeks = [oneWeekAgo, twoWeeksAgo]
+
+        Task(priority: .utility) {
+            // 현재 주를 먼저 완료
+            _ = try? await self.fetchFoodImageAssets(
+                from: currentRange.start,
+                to: currentRange.end
+            )
+
+            // 이전 2주를 병렬로 백그라운드 실행
+            for targetDate in previousWeeks {
+                guard let range = weekRange(for: targetDate) else { continue }
+                Task(priority: .background) {
+                    _ = try? await self.fetchFoodImageAssets(
+                        from: range.start,
+                        to: range.end
+                    )
+                }
+            }
         }
     }
 }

--- a/FoodDiary/Data/Sources/Network/HTTPLogger.swift
+++ b/FoodDiary/Data/Sources/Network/HTTPLogger.swift
@@ -8,16 +8,21 @@ import Logging
 
 public struct HTTPLogger {
     private let logger: Logger
+    private let logBody: Bool
 
-    public init(logger: Logger = Logger(label: "com.fooddiary.network")) {
+    public init(
+        logger: Logger = Logger(label: "com.fooddiary.network"),
+        logBody: Bool = false
+    ) {
         self.logger = logger
+        self.logBody = logBody
     }
 
     func logRequest(_ request: URLRequest) {
             let method = request.httpMethod ?? "UNKNOWN"
             let url = request.url?.absoluteString ?? "nil"
             var message = "[Request] [\(method)] \(url)"
-            if let body = request.httpBody {
+            if logBody, let body = request.httpBody {
                 message += "\nBody:\n\(prettyJSON(body))"
             }
             logger.info("\(message)")
@@ -26,7 +31,9 @@ public struct HTTPLogger {
     func logResponse(_ response: URLResponse, statusCode: Int, data: Data) {
             let url = response.url?.absoluteString ?? "nil"
             var message = "[Response] [\(statusCode)] \(url)"
-            message += "\nBody:\n\(prettyJSON(data))"
+            if logBody {
+                message += "\nBody:\n\(prettyJSON(data))"
+            }
         if (200..<300).contains(statusCode) {
             logger.info("\(message)")
             } else {
@@ -35,6 +42,7 @@ public struct HTTPLogger {
     }
 
     func logRequestBody(_ body: Data?) {
+            guard logBody else { return }
             guard let body else {
                 logger.info("[Request Body] (empty)")
                 return
@@ -44,6 +52,7 @@ public struct HTTPLogger {
     }
 
     func logResponseBody(_ data: Data) {
+            guard logBody else { return }
             let bodyString = String(data: data, encoding: .utf8) ?? "(binary \(data.count) bytes)"
             logger.info("[Response Body] \(bodyString)")
     }

--- a/FoodDiary/Domain/Sources/Repository/FoodImageAssetRepository.swift
+++ b/FoodDiary/Domain/Sources/Repository/FoodImageAssetRepository.swift
@@ -20,7 +20,9 @@ public protocol FoodImageAssetRepository: Sendable {
         to endDate: Date?
     ) async throws -> [Date: [FoodImageAsset<Asset>]]
 
-    /// 인접 주간 사진 데이터를 미리 로드하여 캐시 워밍 (이전 주 + 현재 주 + 다음 주)
-    /// - Parameter date: 기준 날짜
-    func prefetchFoodImageAssets(forAdjacentWeeksOf date: Date)
+    /// 현재 주 + 과거 N주 범위의 사진 데이터를 백그라운드에서 미리 로드하여 캐시 워밍
+    /// - Parameters:
+    ///   - weekCount: 과거 몇 주를 prefetch할지
+    ///   - date: 기준 날짜
+    func prefetchFoodImageAssets(forPreviousWeeks weekCount: Int, of date: Date)
 }

--- a/FoodDiary/Domain/Sources/Repository/FoodImageAssetRepository.swift
+++ b/FoodDiary/Domain/Sources/Repository/FoodImageAssetRepository.swift
@@ -20,7 +20,7 @@ public protocol FoodImageAssetRepository: Sendable {
         to endDate: Date?
     ) async throws -> [Date: [FoodImageAsset<Asset>]]
 
-    /// 주간 사진 데이터를 미리 로드하여 캐시 워밍
-    /// - Parameter date: 주의 기준이 되는 날짜
-    func prefetchFoodImageAssets(forWeekContaining date: Date)
+    /// 인접 주간 사진 데이터를 미리 로드하여 캐시 워밍 (이전 주 + 현재 주 + 다음 주)
+    /// - Parameter date: 기준 날짜
+    func prefetchFoodImageAssets(forAdjacentWeeksOf date: Date)
 }

--- a/FoodDiary/Domain/Sources/UseCase/FetchFoodImageAssetUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/FetchFoodImageAssetUseCase.swift
@@ -24,9 +24,9 @@ public struct FetchFoodImageAssetUseCase<Repository: FoodImageAssetRepository> {
         }.value
     }
 
-    /// 주간 사진 데이터를 백그라운드에서 미리 로드하여 캐시 워밍
-    /// - Parameter date: 주의 기준이 되는 날짜
+    /// 인접 주간 사진 데이터를 백그라운드에서 미리 로드하여 캐시 워밍
+    /// - Parameter date: 기준 날짜
     public func prefetch(for date: Date) {
-        repository.prefetchFoodImageAssets(forWeekContaining: date)
+        repository.prefetchFoodImageAssets(forAdjacentWeeksOf: date)
     }
 }

--- a/FoodDiary/Domain/Sources/UseCase/FetchFoodImageAssetUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/FetchFoodImageAssetUseCase.swift
@@ -24,9 +24,11 @@ public struct FetchFoodImageAssetUseCase<Repository: FoodImageAssetRepository> {
         }.value
     }
 
-    /// 인접 주간 사진 데이터를 백그라운드에서 미리 로드하여 캐시 워밍
-    /// - Parameter date: 기준 날짜
-    public func prefetch(for date: Date) {
-        repository.prefetchFoodImageAssets(forAdjacentWeeksOf: date)
+    /// 현재 주 + 과거 N주 사진 데이터를 백그라운드에서 미리 로드하여 캐시 워밍
+    /// - Parameters:
+    ///   - weekCount: 과거 몇 주를 prefetch할지
+    ///   - date: 기준 날짜
+    public func prefetch(forPreviousWeeks weekCount: Int, of date: Date) {
+        repository.prefetchFoodImageAssets(forPreviousWeeks: weekCount, of: date)
     }
 }

--- a/FoodDiary/Domain/Sources/UseCase/LoadWeeklyRecordUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/LoadWeeklyRecordUseCase.swift
@@ -51,7 +51,7 @@ public struct LoadWeeklyRecordUseCase<
         for date: Date,
         locale: Locale = Locale(identifier: "ko_KR")
     ) async throws -> WeekData {
-        fetchFoodImageAssetUseCase.prefetch(for: date)
+        fetchFoodImageAssetUseCase.prefetch(forPreviousWeeks: 2, of: date)
 
         let (weekStart, weekEnd) = calendar.weekRange(for: date)
         let weekDates = calendar.weekDates(from: weekStart)

--- a/FoodDiary/Domain/Tests/Mock/MockFoodImageAssetRepository.swift
+++ b/FoodDiary/Domain/Tests/Mock/MockFoodImageAssetRepository.swift
@@ -17,7 +17,7 @@ final class MockFoodImageAssetRepository: FoodImageAssetRepository, @unchecked S
         resultToReturn
     }
 
-    func prefetchFoodImageAssets(forAdjacentWeeksOf date: Date) {
+    func prefetchFoodImageAssets(forPreviousWeeks weekCount: Int, of date: Date) {
         // Mock에서는 아무 동작도 하지 않음
     }
 }

--- a/FoodDiary/Domain/Tests/Mock/MockFoodImageAssetRepository.swift
+++ b/FoodDiary/Domain/Tests/Mock/MockFoodImageAssetRepository.swift
@@ -17,7 +17,7 @@ final class MockFoodImageAssetRepository: FoodImageAssetRepository, @unchecked S
         resultToReturn
     }
 
-    func prefetchFoodImageAssets(forWeekContaining date: Date) {
+    func prefetchFoodImageAssets(forAdjacentWeeksOf date: Date) {
         // Mock에서는 아무 동작도 하지 않음
     }
 }

--- a/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/WeeklyCalendarViewController.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/WeeklyCalendarViewController.swift
@@ -132,9 +132,6 @@ public final class WeeklyCalendarViewController<
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-34)
         }
 
-        imagePickerLoadingView.snp.makeConstraints {
-            $0.center.equalTo(bottomContentView)
-        }
     }
 
     private func setupBindings() {
@@ -261,13 +258,8 @@ public final class WeeklyCalendarViewController<
 
     private func setImagePickerLoading(_ isLoading: Bool) {
         isLoadingImagePicker = isLoading
-        if isLoading {
-            imagePickerLoadingView.startAnimating()
-        } else {
-            imagePickerLoadingView.stopAnimating()
-        }
-        bottomContentView.alpha = isLoading ? 0.5 : 1.0
         bottomContentView.isUserInteractionEnabled = !isLoading
+        bottomContentView.alpha = isLoading ? 0.5 : 1.0
     }
 
     // MARK: - Actions

--- a/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/WeeklyCalendarViewController.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/WeeklyCalendarViewController.swift
@@ -55,9 +55,17 @@ public final class WeeklyCalendarViewController<
         return sv
     }()
 
+    private let imagePickerLoadingView: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.color = .gray400
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
     // MARK: - State
 
     private var cancellables = Set<AnyCancellable>()
+    private var isLoadingImagePicker = false
 
     // MARK: - Init
 
@@ -100,10 +108,11 @@ public final class WeeklyCalendarViewController<
 
     private func setupUI() {
         view.backgroundColor = .sdBase
-        
+
         view.addSubview(recordPromptHeaderView)
         view.addSubview(headerView)
         view.addSubview(containerStackView)
+        view.addSubview(imagePickerLoadingView)
     }
 
     private func setupConstraints() {
@@ -121,6 +130,10 @@ public final class WeeklyCalendarViewController<
             $0.top.equalTo(headerView.snp.bottom).offset(14)
             $0.leading.trailing.equalToSuperview().inset(Constants.horizontalInset)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-34)
+        }
+
+        imagePickerLoadingView.snp.makeConstraints {
+            $0.center.equalTo(bottomContentView)
         }
     }
 
@@ -244,9 +257,23 @@ public final class WeeklyCalendarViewController<
             .store(in: &cancellables)
     }
 
+    // MARK: - Image Picker Loading
+
+    private func setImagePickerLoading(_ isLoading: Bool) {
+        isLoadingImagePicker = isLoading
+        if isLoading {
+            imagePickerLoadingView.startAnimating()
+        } else {
+            imagePickerLoadingView.stopAnimating()
+        }
+        bottomContentView.alpha = isLoading ? 0.5 : 1.0
+        bottomContentView.isUserInteractionEnabled = !isLoading
+    }
+
     // MARK: - Actions
 
     private func handleAddButtonTap() {
+        guard !isLoadingImagePicker else { return }
         if viewModel.checkPhotoAuthorizationForAddingPhoto() {
             Task {
                 await presentImagePicker()
@@ -279,6 +306,9 @@ public final class WeeklyCalendarViewController<
 
     @MainActor
     private func presentImagePicker() async {
+        setImagePickerLoading(true)
+        defer { setImagePickerLoading(false) }
+
         let selectedDate = viewModel.state.selectedDate
 
         do {


### PR DESCRIPTION
## ✏️ 변경 내용
- 이미지 에셋 프리페치 범위를 인접 2주로 확장 (LoadWeeklyRecordUseCase)
- 온보딩 진입 시 사진 권한 요청 후 과거 4주치 프리페치 시작
- 에셋 분류/페치 과정에 상세 로그 추가 (Logger)
- HTTP 로그 바디 on/off 옵션 추가
- 이미지 피커 로딩 중 중복 진입 방지

## ✅ 체크리스트
- [x] 빌드 정상 동작
- [x] 불필요한 파일 없음