### PR TITLE
FCM 토큰 리프레시 로직 적용

### DIFF
--- a/FoodDiary/App/Sources/AppDelegate.swift
+++ b/FoodDiary/App/Sources/AppDelegate.swift
@@ -171,9 +171,17 @@ extension AppDelegate: MessagingDelegate {
         guard let fcmToken else { return }
         print("[FCM] 토큰 수신: \(fcmToken)")
 
-        // TODO: 서버 API로 fcmToken 전송
-        // TODO: self.container로 사용해야 함.
         try? DIContainer.shared.resolve(PushTokenStoring.self).set(fcmToken)
+
+        guard let useCase = try? DIContainer.shared.resolve(UpdateDeviceNotificationSettingUseCase.self) else {
+            print("[FCM] 로그인 전 토큰 수신 - 서버 업데이트 스킵")
+            return
+        }
+
+        Task {
+            try? await useCase.execute()
+            print("[FCM] 서버 디바이스 토큰 업데이트 완료")
+        }
     }
 }
 

--- a/FoodDiary/App/Sources/AppFlowController.swift
+++ b/FoodDiary/App/Sources/AppFlowController.swift
@@ -118,7 +118,7 @@ extension AppFlowController {
         guard
             let validateAccessTokenUseCase = try? container.resolve(
                 ValidateAccessTokenUseCase<
-                    TokenRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
+                    TokenRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>, InitialLaunchStorage>
                 >.self
             )
         else {

--- a/FoodDiary/App/Sources/SceneDelegate.swift
+++ b/FoodDiary/App/Sources/SceneDelegate.swift
@@ -82,15 +82,13 @@ extension SceneDelegate {
         }
 
         container.register(TokenRepository.self) { resolver in
-            guard let client = resolver.resolve(HTTPClient.self) else {
-                fatalError("HTTPClient not registered")
+            guard let client = resolver.resolve(HTTPClient.self),
+                  let storage = resolver.resolve(AuthTokenStorage<KeychainService>.self),
+                  let launchStorage = resolver.resolve(InitialLaunchStorage.self) else {
+                fatalError("TokenRepositoryImpl dependencies not registered")
             }
 
-            guard let storage = resolver.resolve(AuthTokenStorage<KeychainService>.self) else {
-                fatalError("AuthTokenStorage not registered")
-            }
-
-            return TokenRepositoryImpl(httpClient: client, storage: storage)
+            return TokenRepositoryImpl(httpClient: client, storage: storage, launchStorage: launchStorage)
         }
 
         container.register(PHAssetConverter.self) { _ in
@@ -182,6 +180,10 @@ extension SceneDelegate {
         container.register(NicknameStoring.self) { _ in
             NicknameStorage()
         }
+
+        container.register(InitialLaunchStorage.self) { _ in
+            InitialLaunchStorage()
+        }
     }
 
     fileprivate func registerDomain() {
@@ -190,6 +192,7 @@ extension SceneDelegate {
                 let pushTokenStorage = resolver.resolve(PushTokenStoring.self),
                 let notificationAuthProvider = resolver.resolve(
                     NotificationAuthorizationProviding.self),
+                let launchStorage = resolver.resolve(InitialLaunchStorage.self),
                 let deviceId = UIDevice.current.identifierForVendor?.uuidString
             else {
                 fatalError("FinalizeAppleLoginUseCase dependencies not registered")
@@ -200,13 +203,14 @@ extension SceneDelegate {
                 deviceId: deviceId,
                 osVersion: UIDevice.current.systemVersion,
                 pushTokenStorage: pushTokenStorage,
-                notificationAuthorizationProvider: notificationAuthProvider
+                notificationAuthorizationProvider: notificationAuthProvider,
+                initialLaunchStorage: launchStorage
             )
         }
 
         container.register(
             ValidateAccessTokenUseCase<
-                TokenRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
+                TokenRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>, InitialLaunchStorage>
             >.self
         ) { resolver in
             guard let repository = resolver.resolve(TokenRepository.self) else {
@@ -215,7 +219,7 @@ extension SceneDelegate {
 
             guard
                 let concreteRepository = repository
-                    as? TokenRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
+                    as? TokenRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>, InitialLaunchStorage>
             else {
                 fatalError("TokenRepository is not of expected type")
             }

--- a/FoodDiary/Data/Sources/Core/InitialLaunch/InitialLaunchStorage.swift
+++ b/FoodDiary/Data/Sources/Core/InitialLaunch/InitialLaunchStorage.swift
@@ -1,0 +1,23 @@
+//
+//  InitialLaunchStorage.swift
+//  Data
+//
+//  Created by 강대훈 on 2/26/26.
+//
+
+import Domain
+import Foundation
+
+public struct InitialLaunchStorage: InitialLaunchStoring {
+    private let key = "initial_launch"
+
+    public init() {}
+
+    public func get() -> Bool {
+        UserDefaults.standard.bool(forKey: key)
+    }
+
+    public func set() {
+        UserDefaults.standard.set(true, forKey: key)
+    }
+}

--- a/FoodDiary/Data/Sources/Repository/TokenRepository.swift
+++ b/FoodDiary/Data/Sources/Repository/TokenRepository.swift
@@ -8,16 +8,24 @@
 import Domain
 import Foundation
 
-public struct TokenRepositoryImpl<Client: HTTPClienting, Storage: AuthTokenStoring>: TokenRepository {
+public struct TokenRepositoryImpl<
+    Client: HTTPClienting,
+    Storage: AuthTokenStoring,
+    LaunchStorage: InitialLaunchStoring
+>: TokenRepository {
     let httpClient: Client
     let storage: Storage
+    let launchStorage: LaunchStorage
 
-    public init(httpClient: Client, storage: Storage) {
+    public init(httpClient: Client, storage: Storage, launchStorage: LaunchStorage) {
         self.httpClient = httpClient
         self.storage = storage
+        self.launchStorage = launchStorage
     }
 
     public func verifyToken() async -> Bool {
+        guard launchStorage.get() else { return false }
+        
         guard let accessToken = storage.get() else {
             return false
         }
@@ -25,7 +33,7 @@ public struct TokenRepositoryImpl<Client: HTTPClienting, Storage: AuthTokenStori
         guard let _: ValidateResponseDTO = try? await httpClient.request(AuthEndpoint.verify, accessToken: accessToken) else {
             return false
         }
-        
+
         return true
     }
 }

--- a/FoodDiary/Domain/Sources/Core/InitialLaunch/InitialLaunchStoring.swift
+++ b/FoodDiary/Domain/Sources/Core/InitialLaunch/InitialLaunchStoring.swift
@@ -1,0 +1,13 @@
+//
+//  InitialLaunchStoring.swift
+//  Domain
+//
+//  Created by 강대훈 on 2/26/26.
+//
+
+import Foundation
+
+public protocol InitialLaunchStoring {
+    func get() -> Bool
+    func set()
+}

--- a/FoodDiary/Domain/Sources/UseCase/FinalizeAppleLoginUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/FinalizeAppleLoginUseCase.swift
@@ -18,19 +18,22 @@ public struct FinalizeAppleLoginUseCase {
     private let osVersion: String
     private let pushTokenStorage: PushTokenStoring
     private let notificationAuthorizationProvider: NotificationAuthorizationProviding
+    private let initialLaunchStorage: InitialLaunchStoring
 
     public init(
         authRepository: AuthRepository,
         deviceId: String,
         osVersion: String,
         pushTokenStorage: PushTokenStoring,
-        notificationAuthorizationProvider: NotificationAuthorizationProviding
+        notificationAuthorizationProvider: NotificationAuthorizationProviding,
+        initialLaunchStorage: InitialLaunchStoring
     ) {
         self.authRepository = authRepository
         self.deviceId = deviceId
         self.osVersion = osVersion
         self.pushTokenStorage = pushTokenStorage
         self.notificationAuthorizationProvider = notificationAuthorizationProvider
+        self.initialLaunchStorage = initialLaunchStorage
     }
 
     public func execute(_ appleIdentityToken: String) async throws -> LoginResult {
@@ -46,7 +49,8 @@ public struct FinalizeAppleLoginUseCase {
             notificationEnabled: notificationEnabled
         )
 
-        // 로그인 요청
-        return try await authRepository.login(loginRequest)
+        let result = try await authRepository.login(loginRequest)
+        initialLaunchStorage.set()
+        return result
     }
 }


### PR DESCRIPTION
## ✏️ 변경 내용
- FCM 토큰 리프레시
- 앱 삭제 후 설치시에 로그인 화면으로 분기되도록 적용

FCM 토큰 리프레시 될 때마다 `UpdateDeviceNotificationSettingUseCase` 실행해서 토큰 리프레시 하도록 했습니다~

## ✅ 체크리스트
- [x] 빌드 정상 동작
- [x] 불필요한 파일 없음