### PR TITLE
fix: QA 버그 수정 (웹이미지, 온보딩 알림)

### DIFF
--- a/FoodDiary/App/Sources/AppFlowController.swift
+++ b/FoodDiary/App/Sources/AppFlowController.swift
@@ -248,30 +248,14 @@ extension AppFlowController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
+                registerForRemoteNotificationsAfterLogin()
                 let mainVC = createMainView()
                 transition(to: mainVC)
                 showCoachmarkOverlay(on: mainVC)
             }
             .store(in: &cancellables)
 
-        prefetchInitialFoodImageAssets()
-
         return UINavigationController(rootViewController: onboardingVC)
-    }
-
-    /// 온보딩 진입 시 사진 권한 획득 → 과거 4주치 FoodImageAsset prefetch
-    private func prefetchInitialFoodImageAssets() {
-        guard let authUseCase = try? container.resolve(AuthUseCase.self),
-              let fetchUseCase = try? container.resolve(FetchUseCase.self)
-        else { return }
-
-        Task {
-            if !authUseCase.isAuthorized() {
-                let status = await authUseCase.execute()
-                guard status == .authorized || status == .limited else { return }
-            }
-            fetchUseCase.prefetch(forPreviousWeeks: 4, of: Date())
-        }
     }
 
     fileprivate func showCoachmarkOverlay(on viewController: UIViewController) {
@@ -317,7 +301,9 @@ extension AppFlowController {
     fileprivate func handleLoginResult(_ loginResult: LoginResult) {
         Task {
             try? await fetchUserProfile()
-            registerForRemoteNotificationsAfterLogin()
+            if !loginResult.isFirst {
+                registerForRemoteNotificationsAfterLogin()
+            }
             transition(to: loginResult.isFirst ? createOnboardingView() : createMainView())
         }
     }

--- a/FoodDiary/Presentation/Sources/Components/FoodRecordCardView.swift
+++ b/FoodDiary/Presentation/Sources/Components/FoodRecordCardView.swift
@@ -27,6 +27,7 @@ public final class FoodRecordCardView: UIView {
     // MARK: - State
 
     private let imageURL: URL?
+    private var isConfigured = false
 
     // MARK: - UI Components
 
@@ -67,12 +68,18 @@ public final class FoodRecordCardView: UIView {
         super.init(frame: .zero)
         setupUI()
         setupConstraints()
-        configure()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard window != nil, !isConfigured else { return }
+        isConfigured = true
+        configure()
     }
 
     // MARK: - Setup


### PR DESCRIPTION
## ✏️ 변경 내용
- 웹이미지가 표시되지 않는 문제 수정 (`FoodRecordCardView`의 `configure()`를 `didMoveToWindow()` 시점으로 지연)
- 온보딩 시작 시 불필요한 prefetch 로직 삭제
- 알림 등록 시점을 온보딩 완료 후로 변경 (첫 로그인 시 온보딩 진입 전 알림 등록되던 문제)

## ✅ 체크리스트
- [x] 빌드 정상 동작
- [x] 불필요한 파일 없음