### PR TITLE
feat: 빈 상태에서 음식 사진 유무에 따라 분기 표시

### DIFF
--- a/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/Components/BottomContentView.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/Components/BottomContentView.swift
@@ -129,8 +129,8 @@ final class BottomContentView: UIView {
         currentState = state
 
         switch state {
-        case .empty:
-            showEmptyState()
+        case .empty(let hasPhotos):
+            showEmptyState(hasPhotos: hasPhotos)
         case .processing(let records):
             if let first = records.first {
                 showProcessingState(record: first)
@@ -182,7 +182,7 @@ final class BottomContentView: UIView {
         containerView.layer.borderWidth = show ? Constants.containerBorderWidth : 0
     }
 
-    private func showEmptyState() {
+    private func showEmptyState(hasPhotos: Bool) {
         cardStackStateView.isHidden = true
         processingStateView.isHidden = true
         showContainerStyle(false)
@@ -192,7 +192,12 @@ final class BottomContentView: UIView {
         cancellables.removeAll()
 
         // 새로 생성
-        let newEmptyView = EmptyFoodRecordView(text: "오늘의 음식 사진을 추가해보세요")
+        let newEmptyView = EmptyFoodRecordView(
+            text: hasPhotos
+                ? "오늘의 음식 사진을 추가해보세요"
+                : "기록 가능한 음식 사진이 없어요",
+            style: hasPhotos ? .addable : .unavailable
+        )
         containerView.addSubview(newEmptyView)
         emptyStateView = newEmptyView
 
@@ -200,12 +205,14 @@ final class BottomContentView: UIView {
             $0.edges.equalToSuperview()
         }
 
-        // Publisher 바인딩
-        newEmptyView.addButtonTapPublisher
-            .sink { [weak self] in
-                self?.addButtonTapSubject.send()
-            }
-            .store(in: &cancellables)
+        // 사진이 있을 때만 탭 Publisher 바인딩
+        if hasPhotos {
+            newEmptyView.addButtonTapPublisher
+                .sink { [weak self] in
+                    self?.addButtonTapSubject.send()
+                }
+                .store(in: &cancellables)
+        }
     }
 
     private func showCardStackState(record: FoodRecord, totalCount: Int) {
@@ -245,7 +252,7 @@ final class BottomContentView: UIView {
 
 extension BottomContentView {
     enum State: Equatable {
-        case empty
+        case empty(hasPhotos: Bool)
         case processing([FoodRecord])
         case recorded([FoodRecord])
     }

--- a/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/ViewModel/WeeklyCalendarViewModel.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/ViewModel/WeeklyCalendarViewModel.swift
@@ -194,10 +194,28 @@ public final class WeeklyCalendarViewModel<
         let completedRecords = allRecords.filter { !$0.isProcessing }
         let processingRecords = allRecords.filter { $0.isProcessing }
 
+        var hasFoodPhotos = false
+        if completedRecords.isEmpty && processingRecords.isEmpty {
+            hasFoodPhotos = await checkFoodPhotosExist(for: date)
+        }
+
         state.dateContent = DateContent(
             records: completedRecords,
-            processingRecords: processingRecords
+            processingRecords: processingRecords,
+            hasFoodPhotos: hasFoodPhotos
         )
+    }
+
+    private func checkFoodPhotosExist(for date: Date) async -> Bool {
+        guard requestPhotoAuthorizationUseCase.isAuthorized() else {
+            return false
+        }
+        do {
+            let photos = try await loadWeeklyCalendarDataUseCase.loadPhotos(for: date)
+            return !photos.isEmpty
+        } catch {
+            return false
+        }
     }
 
     @MainActor
@@ -318,6 +336,7 @@ extension WeeklyCalendarViewModel {
     public struct DateContent: Equatable {
         public let records: [FoodRecord]
         public let processingRecords: [FoodRecord]
+        public let hasFoodPhotos: Bool
     }
 }
 

--- a/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/WeeklyCalendarViewController.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/WeeklyCalendarViewController.swift
@@ -213,7 +213,7 @@ public final class WeeklyCalendarViewController<
                     } else if !content.processingRecords.isEmpty {
                         .processing(content.processingRecords)
                     } else {
-                        .empty
+                        .empty(hasPhotos: content.hasFoodPhotos)
                     }
 
                 bottomContentView.configure(state: state)

--- a/FoodDiary/Presentation/Sources/Components/EmptyFoodRecordView.swift
+++ b/FoodDiary/Presentation/Sources/Components/EmptyFoodRecordView.swift
@@ -11,6 +11,13 @@ import UIKit
 /// 음식 기록이 없을 때 표시되는 빈 상태 뷰
 final class EmptyFoodRecordView: UIView {
 
+    // MARK: - Style
+
+    enum Style {
+        case addable
+        case unavailable
+    }
+
     // MARK: - Constants
 
     private enum Constants {
@@ -35,7 +42,6 @@ final class EmptyFoodRecordView: UIView {
 
     private let addImageView: UIImageView = {
         let iv = UIImageView()
-        iv.image = DesignSystemAsset.add.image
         iv.contentMode = .scaleAspectFit
         return iv
     }()
@@ -49,11 +55,13 @@ final class EmptyFoodRecordView: UIView {
 
     // MARK: - Init
 
-    init(text: String) {
+    init(text: String, style: Style = .addable) {
         super.init(frame: .zero)
-        setupUI()
+        setupUI(style: style)
         setupConstraints()
-        setupActions()
+        if style == .addable {
+            setupActions()
+        }
         placeholderLabel.setText(text, style: .p14, color: .gray050)
     }
 
@@ -64,13 +72,20 @@ final class EmptyFoodRecordView: UIView {
 
     // MARK: - Setup
 
-    private func setupUI() {
+    private func setupUI(style: Style) {
         dashedBorderView.cornerRadius = Constants.cornerRadius
         dashedBorderView.backgroundColor = .sd900
         dashedBorderView.layer.cornerRadius = Constants.cornerRadius
         dashedBorderView.clipsToBounds = true
         addSubview(dashedBorderView)
         dashedBorderView.addSubview(contentView)
+
+        switch style {
+        case .addable:
+            addImageView.image = DesignSystemAsset.add.image
+        case .unavailable:
+            addImageView.image = DesignSystemAsset.emptyMeal.image
+        }
 
         contentView.addSubview(addImageView)
         contentView.addSubview(placeholderLabel)


### PR DESCRIPTION
## ✏️ 변경 내용

위클리 캘린더에서 선택한 날짜에 음식 기록이 없을 때, 사진 라이브러리에 해당 날짜의 음식 사진이 있는지 미리 조회하여 빈 상태를 두 가지로 분기합니다.

- **음식 사진이 있는 경우**: "오늘의 음식 사진을 추가해보세요" (탭 → 이미지 피커)
- **음식 사진이 없는 경우**: "기록 가능한 음식 사진이 없어요" (탭 비활성화, emptyMeal 아이콘)

### 변경 파일
- `WeeklyCalendarViewModel` - `DateContent`에 `hasFoodPhotos` 필드 추가, empty 상태일 때 사진 존재 여부 조회
- `BottomContentView` - `State.empty(hasPhotos:)`로 변경, 사진 유무에 따라 탭 바인딩 분기
- `EmptyFoodRecordView` - `Style` enum 추가 (`.addable` / `.unavailable`)
- `WeeklyCalendarViewController` - empty 상태에 `hasFoodPhotos` 전달

## ✅ 체크리스트
- [x] 빌드 정상 동작
- [x] 불필요한 파일 없음