### PR TITLE
iPad 설정 제거

### DIFF
--- a/FoodDiary/App/Project.swift
+++ b/FoodDiary/App/Project.swift
@@ -34,7 +34,8 @@ let project = Project(
             settings: .settings(
                 base: [
                     "MARKETING_VERSION": "1.0.0",
-                    "BASE_URL": "$(BASE_URL)"
+                    "BASE_URL": "$(BASE_URL)",
+                    "TARGETED_DEVICE_FAMILY": "1"
                 ],
                 configurations: []
             )


### PR DESCRIPTION
## ✏️ 변경 내용
- iPad 설정 제거

```swift
TARGETED_DEVICE_FAMILY = 1 // iPhone 전용 앱으로 설정
```

## ✅ 체크리스트
- [x] 빌드 정상 동작
- [x] 불필요한 파일 없음