### PR TITLE
feat: Insight 화면 UI 컴포넌트 리디자인

### DIFF
--- a/FoodDiary/Presentation/Sources/Core/Typography.swift
+++ b/FoodDiary/Presentation/Sources/Core/Typography.swift
@@ -26,6 +26,8 @@ public enum Typography {
     case hd18
     /// 페이지 서브 타이틀 2nd - 16pt Bold
     case hd16
+    /// 소형 헤드라인 - 15pt Bold
+    case hd15
 
     // MARK: - Paragraph (Regular, 120% line height)
     /// 본문 - 18pt Regular
@@ -50,6 +52,8 @@ public enum Typography {
             return DesignSystemFontFamily.Pretendard.bold.font(size: 18)
         case .hd16:
             return DesignSystemFontFamily.Pretendard.bold.font(size: 16)
+        case .hd15:
+            return DesignSystemFontFamily.Pretendard.bold.font(size: 15)
         case .p18:
             return DesignSystemFontFamily.Pretendard.regular.font(size: 18)
         case .p15:

--- a/FoodDiary/Presentation/Sources/Insight/Components/GradientBarView.swift
+++ b/FoodDiary/Presentation/Sources/Insight/Components/GradientBarView.swift
@@ -1,0 +1,33 @@
+//
+//  GradientBarView.swift
+//  Presentation
+//
+
+import UIKit
+
+final class GradientBarView: UIView {
+
+    private let gradientLayer = CAGradientLayer()
+
+    init(colors: [UIColor]) {
+        super.init(frame: .zero)
+        clipsToBounds = true
+        layer.cornerRadius = 4
+        layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+
+        gradientLayer.colors = colors.map(\.cgColor)
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+        layer.insertSublayer(gradientLayer, at: 0)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer.frame = bounds
+    }
+}

--- a/FoodDiary/Presentation/Sources/Insight/Components/InsightDiaryTimeStatsView.swift
+++ b/FoodDiary/Presentation/Sources/Insight/Components/InsightDiaryTimeStatsView.swift
@@ -13,8 +13,6 @@ final class InsightDiaryTimeStatsView: UIView {
     // MARK: - UI Components
 
     private let titleLabel = UILabel()
-    private let subtitleLabel = UILabel()
-    private let descriptionLabel = UILabel()
     private let bigTimeLabel = UILabel()
 
     // MARK: - Init
@@ -40,24 +38,14 @@ final class InsightDiaryTimeStatsView: UIView {
         let hour = diaryTimeStats.mostActiveHour
         let timeText = String(format: "%d:00", hour)
 
-        titleLabel.setText("식사는 늘,", style: .hd18, color: .primary)
+        let attributed = NSMutableAttributedString()
+        attributed.append(Typography.hd15.styled("식사는 늘,\n", color: .white, lineSpacing: 6))
+        attributed.append(Typography.hd15.styled(timeText, color: .primary))
+        attributed.append(Typography.hd15.styled(" 이 제일 많았어요", color: .gray200))
+
+        titleLabel.attributedText = attributed
+        titleLabel.numberOfLines = 0
         addSubview(titleLabel)
-
-        let timeAttr = Typography.hd20.styled(timeText, color: .primary)
-        let suffixAttr = Typography.hd20.styled(" 이 제일 많았어요", color: .gray200)
-        let combined = NSMutableAttributedString()
-        combined.append(timeAttr)
-        combined.append(suffixAttr)
-        subtitleLabel.attributedText = combined
-        addSubview(subtitleLabel)
-
-        descriptionLabel.setText(
-            "이 시간대에 음식 사진이 가장 많이 남았어요.",
-            style: .p14,
-            color: .gray400
-        )
-        descriptionLabel.numberOfLines = 0
-        addSubview(descriptionLabel)
 
         bigTimeLabel.attributedText = NSAttributedString(
             string: timeText,
@@ -76,18 +64,8 @@ final class InsightDiaryTimeStatsView: UIView {
             $0.trailing.lessThanOrEqualToSuperview().inset(20)
         }
 
-        subtitleLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(4)
-            $0.leading.trailing.equalToSuperview().inset(20)
-        }
-
-        descriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(subtitleLabel.snp.bottom).offset(12)
-            $0.leading.trailing.equalToSuperview().inset(20)
-        }
-
         bigTimeLabel.snp.makeConstraints {
-            $0.top.equalTo(descriptionLabel.snp.bottom).offset(24)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(24)
             $0.centerX.equalToSuperview()
             $0.bottom.equalToSuperview().inset(28)
         }

--- a/FoodDiary/Presentation/Sources/Insight/Components/InsightDiaryTimeStatsView.swift
+++ b/FoodDiary/Presentation/Sources/Insight/Components/InsightDiaryTimeStatsView.swift
@@ -3,25 +3,19 @@
 //  Presentation
 //
 
+import DesignSystem
 import Domain
 import SnapKit
 import UIKit
 
 final class InsightDiaryTimeStatsView: UIView {
 
-    // MARK: - Constants
-
-    private enum Constants {
-        static let barMaxHeight: CGFloat = 80
-        static let barWidth: CGFloat = 6
-        static let barSpacing: CGFloat = 4
-    }
-
     // MARK: - UI Components
 
     private let titleLabel = UILabel()
-    private let activeHourLabel = UILabel()
-    private let chartContainerView = UIView()
+    private let subtitleLabel = UILabel()
+    private let descriptionLabel = UILabel()
+    private let bigTimeLabel = UILabel()
 
     // MARK: - Init
 
@@ -29,7 +23,6 @@ final class InsightDiaryTimeStatsView: UIView {
         super.init(frame: .zero)
         setupUI(diaryTimeStats: diaryTimeStats)
         setupConstraints()
-        buildChart(distribution: diaryTimeStats.distribution)
     }
 
     @available(*, unavailable)
@@ -44,15 +37,37 @@ final class InsightDiaryTimeStatsView: UIView {
         layer.cornerRadius = 16
         clipsToBounds = true
 
-        titleLabel.setText("⏰ 기록 시간대", style: .hd18)
+        let hour = diaryTimeStats.mostActiveHour
+        let timeText = String(format: "%d:00", hour)
+
+        titleLabel.setText("식사는 늘,", style: .hd18, color: .primary)
         addSubview(titleLabel)
 
-        let hour = diaryTimeStats.mostActiveHour
-        let hourText = String(format: "%02d시", hour)
-        activeHourLabel.setText("주로 \(hourText)에 기록해요", style: .p15, color: .gray050)
-        addSubview(activeHourLabel)
+        let timeAttr = Typography.hd20.styled(timeText, color: .primary)
+        let suffixAttr = Typography.hd20.styled(" 이 제일 많았어요", color: .gray200)
+        let combined = NSMutableAttributedString()
+        combined.append(timeAttr)
+        combined.append(suffixAttr)
+        subtitleLabel.attributedText = combined
+        addSubview(subtitleLabel)
 
-        addSubview(chartContainerView)
+        descriptionLabel.setText(
+            "이 시간대에 음식 사진이 가장 많이 남았어요.",
+            style: .p14,
+            color: .gray400
+        )
+        descriptionLabel.numberOfLines = 0
+        addSubview(descriptionLabel)
+
+        bigTimeLabel.attributedText = NSAttributedString(
+            string: timeText,
+            attributes: [
+                .font: DesignSystemFontFamily.Pretendard.bold.font(size: 50),
+                .foregroundColor: UIColor.primary
+            ]
+        )
+        bigTimeLabel.textAlignment = .center
+        addSubview(bigTimeLabel)
     }
 
     private func setupConstraints() {
@@ -61,49 +76,20 @@ final class InsightDiaryTimeStatsView: UIView {
             $0.trailing.lessThanOrEqualToSuperview().inset(20)
         }
 
-        activeHourLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
+        subtitleLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(4)
             $0.leading.trailing.equalToSuperview().inset(20)
         }
 
-        chartContainerView.snp.makeConstraints {
-            $0.top.equalTo(activeHourLabel.snp.bottom).offset(16)
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(subtitleLabel.snp.bottom).offset(12)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(Constants.barMaxHeight + 20)
-            $0.bottom.equalToSuperview().inset(20)
-        }
-    }
-
-    private func buildChart(distribution: [HourCount]) {
-        let maxCount = distribution.map(\.count).max() ?? 1
-
-        let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.alignment = .bottom
-        stackView.distribution = .equalSpacing
-        stackView.spacing = Constants.barSpacing
-        chartContainerView.addSubview(stackView)
-
-        stackView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
         }
 
-        for hourCount in distribution {
-            let ratio = maxCount > 0
-                ? CGFloat(hourCount.count) / CGFloat(maxCount)
-                : 0
-            let barHeight = max(2, Constants.barMaxHeight * ratio)
-
-            let barView = UIView()
-            barView.backgroundColor = hourCount.count == maxCount ? .primary : .sd700
-            barView.layer.cornerRadius = Constants.barWidth / 2
-
-            barView.snp.makeConstraints {
-                $0.width.equalTo(Constants.barWidth)
-                $0.height.equalTo(barHeight)
-            }
-
-            stackView.addArrangedSubview(barView)
+        bigTimeLabel.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(24)
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(28)
         }
     }
 }

--- a/FoodDiary/Presentation/Sources/Insight/Components/InsightPhotoStatsView.swift
+++ b/FoodDiary/Presentation/Sources/Insight/Components/InsightPhotoStatsView.swift
@@ -207,32 +207,3 @@ final class InsightPhotoStatsView: UIView {
         }
     }
 }
-
-// MARK: - GradientBarView
-
-private final class GradientBarView: UIView {
-
-    private let gradientLayer = CAGradientLayer()
-
-    init(colors: [UIColor]) {
-        super.init(frame: .zero)
-        clipsToBounds = true
-        layer.cornerRadius = 4
-        layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-
-        gradientLayer.colors = colors.map(\.cgColor)
-        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
-        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
-        layer.insertSublayer(gradientLayer, at: 0)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        gradientLayer.frame = bounds
-    }
-}

--- a/FoodDiary/Presentation/Sources/Insight/Components/InsightTopMenuView.swift
+++ b/FoodDiary/Presentation/Sources/Insight/Components/InsightTopMenuView.swift
@@ -3,20 +3,35 @@
 //  Presentation
 //
 
+import DesignSystem
 import Domain
 import SnapKit
 import UIKit
 
 final class InsightTopMenuView: UIView {
 
+    // MARK: - Constants
+
+    private enum Constants {
+        static let maxBarHeight: CGFloat = 160
+        static let lineCount: Int = 6
+        static let barWidth: CGFloat = 60
+    }
+
     // MARK: - UI Components
 
     private let titleLabel = UILabel()
-    private let menuLabel = UILabel()
+    private let separatorView = UIView()
+    private let chartContainerView = UIView()
+    private let linesStackView = UIStackView()
+    private let barView: GradientBarView
+    private let countLabel = UILabel()
+    private let nameLabel = UILabel()
 
     // MARK: - Init
 
     init(topMenu: TopMenu) {
+        barView = GradientBarView(colors: [.primaryGradientStart, .primaryGradientEnd])
         super.init(frame: .zero)
         setupUI(topMenu: topMenu)
         setupConstraints()
@@ -34,16 +49,53 @@ final class InsightTopMenuView: UIView {
         layer.cornerRadius = 16
         clipsToBounds = true
 
-        titleLabel.setText("🏆 최다 메뉴", style: .hd18)
-        addSubview(titleLabel)
+        setupTitle(name: topMenu.name)
+        setupSeparator()
+        setupChart(count: topMenu.count)
+    }
 
-        menuLabel.setText(
-            "\(topMenu.name) — \(topMenu.count)회 기록",
-            style: .p15,
-            color: .gray050
-        )
-        menuLabel.numberOfLines = 0
-        addSubview(menuLabel)
+    private func setupTitle(name: String) {
+        let attributed = NSMutableAttributedString()
+        attributed.append(Typography.hd15.styled("가장 자주 먹은\n음식은 ", color: .white, lineSpacing: 6))
+        attributed.append(Typography.hd15.styled(name, color: .primary))
+
+        titleLabel.attributedText = attributed
+        titleLabel.numberOfLines = 0
+        addSubview(titleLabel)
+    }
+
+    private func setupSeparator() {
+        separatorView.backgroundColor = .sd800
+        addSubview(separatorView)
+    }
+
+    private func setupChart(count: Int) {
+        addSubview(chartContainerView)
+
+        // Grid lines
+        linesStackView.axis = .vertical
+        linesStackView.distribution = .equalSpacing
+        chartContainerView.addSubview(linesStackView)
+
+        for _ in 0..<Constants.lineCount {
+            let line = UIView()
+            line.backgroundColor = .sd800
+            line.translatesAutoresizingMaskIntoConstraints = false
+            line.heightAnchor.constraint(equalToConstant: 0.5).isActive = true
+            linesStackView.addArrangedSubview(line)
+        }
+
+        // Bar
+        chartContainerView.addSubview(barView)
+
+        countLabel.setText("\(count)회", style: .p12, color: .white)
+        countLabel.textAlignment = .center
+        barView.addSubview(countLabel)
+
+        // Name label below bar
+        nameLabel.setText("총 기록", style: .p10, color: .gray200)
+        nameLabel.textAlignment = .center
+        addSubview(nameLabel)
     }
 
     private func setupConstraints() {
@@ -52,9 +104,36 @@ final class InsightTopMenuView: UIView {
             $0.trailing.lessThanOrEqualToSuperview().inset(20)
         }
 
-        menuLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
+        separatorView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(20)
             $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(0.5)
+        }
+
+        chartContainerView.snp.makeConstraints {
+            $0.top.equalTo(separatorView.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(Constants.maxBarHeight)
+        }
+
+        linesStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        barView.snp.makeConstraints {
+            $0.centerX.bottom.equalToSuperview()
+            $0.width.equalTo(Constants.barWidth)
+            $0.height.equalTo(Constants.maxBarHeight)
+        }
+
+        countLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(6)
+            $0.centerX.equalToSuperview()
+        }
+
+        nameLabel.snp.makeConstraints {
+            $0.top.equalTo(chartContainerView.snp.bottom).offset(8)
+            $0.centerX.equalTo(barView)
             $0.bottom.equalToSuperview().inset(20)
         }
     }


### PR DESCRIPTION
## ✏️ 변경 내용
- Insight 화면의 3개 통계 카드(사진 기록, 최다 메뉴, 기록 시간대) UI 리디자인
- `InsightPhotoStatsView`: 월별 비교 그라데이션 바 차트로 변경
- `InsightTopMenuView`: 바 차트 카드 형태로 변경
- `InsightDiaryTimeStatsView`: 큰 시간 텍스트 중심 레이아웃으로 변경
- `GradientBarView` 공통 컴포넌트 추가
- 그라데이션 컬러 에셋 및 Typography(hd15) 추가

서버 구현이 안돼서.. 아직은 이모냥
<img width="400" alt="image" src="https://github.com/user-attachments/assets/15ac1184-0abb-4e8b-aea7-17ce4d962160" />
### -> 구현예정 내가 쓴 거아니다. API가 내려준거다

## ✅ 체크리스트
- [x] 빌드 정상 동작
- [x] 불필요한 파일 없음