### PR TITLE
권한 체크 및 화면 추가

### DIFF
--- a/FoodDiary/App/Project.swift
+++ b/FoodDiary/App/Project.swift
@@ -17,7 +17,7 @@ let project = Project(
             destinations: [.iPhone],
             product: .app,
             bundleId: "com.fooddiary.ios.app",
-            deploymentTargets: .iOS("18.0"),
+            deploymentTargets: .iOS("26.0"),
             infoPlist: .sceneDelegateApp(),
             sources: ["Sources/**"],
             resources: ["Resources/**"],

--- a/FoodDiary/DI/Project.swift
+++ b/FoodDiary/DI/Project.swift
@@ -15,7 +15,7 @@ let project = Project(
             destinations: [.iPhone],
             product: .framework,
             bundleId: "com.fooddiary.di",
-            deploymentTargets: .iOS("18.0"),
+            deploymentTargets: .iOS("26.0"),
             sources: ["Sources/**"],
             dependencies: [
                 .external(name: "Swinject"),

--- a/FoodDiary/Data/Project.swift
+++ b/FoodDiary/Data/Project.swift
@@ -15,7 +15,7 @@ let project = Project(
             destinations: [.iPhone],
             product: .framework,
             bundleId: "com.fooddiary.data",
-            deploymentTargets: .iOS("18.0"),
+            deploymentTargets: .iOS("26.0"),
             sources: ["Sources/**"],
             resources: ["Resources/**"],
             dependencies: [
@@ -29,7 +29,7 @@ let project = Project(
             destinations: [.iPhone],
             product: .unitTests,
             bundleId: "com.fooddiary.data.tests",
-            deploymentTargets: .iOS("18.0"),
+            deploymentTargets: .iOS("26.0"),
             sources: ["Tests/**"],
             resources: ["Tests/Resources/**"],
             dependencies: [

--- a/FoodDiary/DesignSystem/Project.swift
+++ b/FoodDiary/DesignSystem/Project.swift
@@ -15,7 +15,7 @@ let project = Project(
             destinations: [.iPhone],
             product: .framework,
             bundleId: "com.fooddiary.designsystem",
-            deploymentTargets: .iOS("18.0"),
+            deploymentTargets: .iOS("26.0"),
             sources: ["Sources/**"],
             resources: ["Resources/**"],
             dependencies: [

--- a/FoodDiary/Domain/Project.swift
+++ b/FoodDiary/Domain/Project.swift
@@ -15,7 +15,7 @@ let project = Project(
             destinations: [.iPhone],
             product: .framework,
             bundleId: "com.fooddiary.domain",
-            deploymentTargets: .iOS("18.0"),
+            deploymentTargets: .iOS("26.0"),
             sources: ["Sources/**"],
             dependencies: []
         ),
@@ -24,7 +24,7 @@ let project = Project(
             destinations: [.iPhone],
             product: .unitTests,
             bundleId: "com.fooddiary.domain.tests",
-            deploymentTargets: .iOS("18.0"),
+            deploymentTargets: .iOS("26.0"),
             sources: ["Tests/**"],
             dependencies: [
                 .target(name: "Domain")

--- a/FoodDiary/Presentation/Project.swift
+++ b/FoodDiary/Presentation/Project.swift
@@ -16,7 +16,7 @@ let project = Project(
             destinations: [.iPhone],
             product: .framework,
             bundleId: "com.fooddiary.presentation",
-            deploymentTargets: .iOS("18.0"),
+            deploymentTargets: .iOS("26.0"),
             sources: ["Sources/**"],
             resources: ["Resources/**"],
             dependencies: [
@@ -32,7 +32,7 @@ let project = Project(
             destinations: [.iPhone],
             product: .unitTests,
             bundleId: "com.fooddiary.presentation.tests",
-            deploymentTargets: .iOS("18.0"),
+            deploymentTargets: .iOS("26.0"),
             sources: ["Tests/**"],
             dependencies: [
                 .target(name: "Presentation")


### PR DESCRIPTION
## ✏️ 변경 내용
- 사진 권한이 거부된 경우 설정 앱으로 유도하는 안내 화면(`PermissionViewController`) 추가
- `PermissionCoordinator`, `PermissionSceneFactory` 추가 및 `SceneFactories`에 등록
- `AppFlowController`에서 앱 진입 시 앨범 권한 상태를 확인하여 분기 처리

사진 권한 변경 시 iOS가 앱을 의도적으로 종료시키므로, 권한 체크는 앱의 엔트리 포인트인 `AppFlowController`에서만 수행하도록 했습니다~

<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/eaea9126-0319-46ee-9172-37b56c2c9296" />

---

## ✅ 체크리스트
- [x] 빌드 정상 동작
- [x] 불필요한 파일 없음
