### PR TITLE
제네릭 제거

### DIFF
--- a/FoodDiary/App/Sources/AppFlowController.swift
+++ b/FoodDiary/App/Sources/AppFlowController.swift
@@ -15,9 +15,6 @@ import UIKit
 import UserNotifications
 
 final class AppFlowController: UIViewController, SceneTransitioning {
-    private typealias AssetFetcher = FoodImageAssetFetcher<TFLiteFoodClassifier, UIImageLoader>
-    private typealias FetchUseCase = FetchFoodImageAssetUseCase<AssetFetcher>
-
     private var networkCancellable: AnyCancellable?
     private var cancellables = Set<AnyCancellable>()
     private let container: DIContainer
@@ -187,7 +184,7 @@ extension AppFlowController {
     }
 
     private func prefetchFoodImageAssets() {
-        guard let useCase = try? container.resolve(FetchUseCase.self) else { return }
+        guard let useCase = try? container.resolve(FetchFoodImageAssetUseCase.self) else { return }
         useCase.prefetch(forPreviousWeeks: 2, of: Date())
     }
 
@@ -237,31 +234,16 @@ extension AppFlowController {
     }
 
     fileprivate func validateToken() async -> Bool {
-        guard
-            let validateAccessTokenUseCase = try? container.resolve(
-                ValidateAccessTokenUseCase<
-                    TokenRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>, InitialLaunchStorage>
-                >.self
-            )
-        else {
+        guard let validateAccessTokenUseCase = try? container.resolve(ValidateAccessTokenUseCase.self) else {
             fatalError("ValidateAccessTokenUseCase Failed Resolve")
         }
-
         return await validateAccessTokenUseCase.execute()
     }
 
     fileprivate func fetchUserProfile() async throws {
-        guard
-            let fetchUserProfileUseCase = try? container.resolve(
-                FetchUserProfileUseCase<
-                    UserRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>,
-                    NicknameStorage
-                >.self
-            )
-        else {
+        guard let fetchUserProfileUseCase = try? container.resolve(FetchUserProfileUseCase.self) else {
             fatalError("FetchUserProfileUseCase Failed Resolve")
         }
-
         try await fetchUserProfileUseCase.execute()
     }
 

--- a/FoodDiary/App/Sources/SceneDelegate.swift
+++ b/FoodDiary/App/Sources/SceneDelegate.swift
@@ -59,33 +59,27 @@ extension SceneDelegate {
             HTTPClient()
         }
 
-        container.register(AuthTokenStorage<KeychainService>.self) { resolver in
+        container.register(AuthTokenStorage.self) { resolver in
             guard let service = resolver.resolve(KeychainService.self) else {
                 fatalError("KeychainService not registered")
             }
-
             return AuthTokenStorage(keychainService: service)
         }
 
         container.register(AuthRepository.self) { resolver in
-            guard let storage = resolver.resolve(AuthTokenStorage<KeychainService>.self) else {
-                fatalError("AuthTokenStorage not registered")
+            guard let storage = resolver.resolve(AuthTokenStorage.self),
+                  let client = resolver.resolve(HTTPClient.self) else {
+                fatalError("AuthRepositoryImpl dependencies not registered")
             }
-
-            guard let client = resolver.resolve(HTTPClient.self) else {
-                fatalError("HTTPClient not registered")
-            }
-
             return AuthRepositoryImpl(httpClient: client, tokenStorage: storage)
         }
 
         container.register(TokenRepository.self) { resolver in
             guard let client = resolver.resolve(HTTPClient.self),
-                  let storage = resolver.resolve(AuthTokenStorage<KeychainService>.self),
+                  let storage = resolver.resolve(AuthTokenStorage.self),
                   let launchStorage = resolver.resolve(InitialLaunchStorage.self) else {
                 fatalError("TokenRepositoryImpl dependencies not registered")
             }
-
             return TokenRepositoryImpl(httpClient: client, storage: storage, launchStorage: launchStorage)
         }
 
@@ -112,12 +106,10 @@ extension SceneDelegate {
             ClassificationCacheManager()
         }
 
-        container.register(FoodImageAssetFetcher<TFLiteFoodClassifier, UIImageLoader>.self) {
-            resolver in
+        container.register(FoodImageAssetFetcher.self) { resolver in
             guard let classifier = resolver.resolve(TFLiteFoodClassifier.self),
-                let imageRepository = resolver.resolve(UIImageLoader.self),
-                let cache = resolver.resolve(ClassificationCacheManager.self)
-            else {
+                  let imageRepository = resolver.resolve(UIImageLoader.self),
+                  let cache = resolver.resolve(ClassificationCacheManager.self) else {
                 fatalError("FoodImageAssetFetcher dependencies not registered")
             }
             return FoodImageAssetFetcher(
@@ -127,13 +119,10 @@ extension SceneDelegate {
             )
         }
 
-        container.register(
-            FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>.self
-        ) { resolver in
+        container.register(FoodRecordRepositoryImpl.self) { resolver in
             guard let client = resolver.resolve(HTTPClient.self),
-                let storage = resolver.resolve(AuthTokenStorage<KeychainService>.self),
-                let imageConverter = resolver.resolve(PHAssetConverter.self)
-            else {
+                  let storage = resolver.resolve(AuthTokenStorage.self),
+                  let imageConverter = resolver.resolve(PHAssetConverter.self) else {
                 fatalError("FoodRecordRepositoryImpl dependencies not registered")
             }
             let deviceId = UIDevice.current.identifierForVendor?.uuidString ?? ""
@@ -152,8 +141,7 @@ extension SceneDelegate {
 
         container.register(AddressSearchRepositoryImpl.self) { resolver in
             guard let client = resolver.resolve(HTTPClient.self),
-                let storage = resolver.resolve(AuthTokenStorage<KeychainService>.self)
-            else {
+                  let storage = resolver.resolve(AuthTokenStorage.self) else {
                 fatalError("AddressSearchRepositoryImpl dependencies not registered")
             }
             return AddressSearchRepositoryImpl(httpClient: client, tokenStorage: storage)
@@ -161,7 +149,7 @@ extension SceneDelegate {
 
         container.register(DeviceRepository.self) { resolver in
             guard let client = resolver.resolve(HTTPClient.self),
-                  let storage = resolver.resolve(AuthTokenStorage<KeychainService>.self) else {
+                  let storage = resolver.resolve(AuthTokenStorage.self) else {
                 fatalError("DeviceRepository dependencies not registered")
             }
             return DeviceRepositoryImpl(httpClient: client, tokenStorage: storage)
@@ -169,15 +157,15 @@ extension SceneDelegate {
 
         container.register(UserRepository.self) { resolver in
             guard let client = resolver.resolve(HTTPClient.self),
-                  let storage = resolver.resolve(AuthTokenStorage<KeychainService>.self) else {
+                  let storage = resolver.resolve(AuthTokenStorage.self) else {
                 fatalError("UserRepositoryImpl dependencies not registered")
             }
             return UserRepositoryImpl(httpClient: client, tokenStorage: storage)
         }
 
-        container.register(InsightRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>.self) { resolver in
+        container.register(InsightRepositoryImpl.self) { resolver in
             guard let client = resolver.resolve(HTTPClient.self),
-                  let storage = resolver.resolve(AuthTokenStorage<KeychainService>.self) else {
+                  let storage = resolver.resolve(AuthTokenStorage.self) else {
                 fatalError("InsightRepositoryImpl dependencies not registered")
             }
             return InsightRepositoryImpl(httpClient: client, tokenStorage: storage)
@@ -207,16 +195,13 @@ extension SceneDelegate {
 
         container.register(FinalizeAppleLoginUseCase.self) { resolver in
             guard let repository = resolver.resolve(AuthRepository.self),
-                let pushTokenStorage = resolver.resolve(PushTokenStoring.self),
-                let notificationAuthProvider = resolver.resolve(
-                    NotificationAuthorizationProviding.self),
-                let launchStorage = resolver.resolve(InitialLaunchStorage.self),
-                let loginSession = resolver.resolve(LoginSession.self),
-                let deviceId = UIDevice.current.identifierForVendor?.uuidString
-            else {
+                  let pushTokenStorage = resolver.resolve(PushTokenStoring.self),
+                  let notificationAuthProvider = resolver.resolve(NotificationAuthorizationProviding.self),
+                  let launchStorage = resolver.resolve(InitialLaunchStorage.self),
+                  let loginSession = resolver.resolve(LoginSession.self),
+                  let deviceId = UIDevice.current.identifierForVendor?.uuidString else {
                 fatalError("FinalizeAppleLoginUseCase dependencies not registered")
             }
-
             return FinalizeAppleLoginUseCase(
                 authRepository: repository,
                 deviceId: deviceId,
@@ -228,104 +213,51 @@ extension SceneDelegate {
             )
         }
 
-        container.register(
-            ValidateAccessTokenUseCase<
-                TokenRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>, InitialLaunchStorage>
-            >.self
-        ) { resolver in
+        container.register(ValidateAccessTokenUseCase.self) { resolver in
             guard let repository = resolver.resolve(TokenRepository.self) else {
                 fatalError("TokenRepository not registered")
             }
-
-            guard
-                let concreteRepository = repository
-                    as? TokenRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>, InitialLaunchStorage>
-            else {
-                fatalError("TokenRepository is not of expected type")
-            }
-
-            return ValidateAccessTokenUseCase(repository: concreteRepository)
+            return ValidateAccessTokenUseCase(repository: repository)
         }
 
-        container.register(
-            FetchFoodImageAssetUseCase<FoodImageAssetFetcher<TFLiteFoodClassifier, UIImageLoader>>
-                .self
-        ) { resolver in
-            guard
-                let repository = resolver.resolve(
-                    FoodImageAssetFetcher<TFLiteFoodClassifier, UIImageLoader>.self)
-            else {
+        container.register(FetchFoodImageAssetUseCase.self) { resolver in
+            guard let repository = resolver.resolve(FoodImageAssetFetcher.self) else {
                 fatalError("FoodImageAssetFetcher not registered")
             }
             return FetchFoodImageAssetUseCase(repository: repository)
         }
 
-        container.register(
-            RequestPhotoAuthorizationUseCase<PhotoAuthorizationFetcher>.self
-        ) { resolver in
+        container.register(RequestPhotoAuthorizationUseCase.self) { resolver in
             guard let repository = resolver.resolve(PhotoAuthorizationFetcher.self) else {
                 fatalError("PhotoAuthorizationFetcher not registered")
             }
             return RequestPhotoAuthorizationUseCase(repository: repository)
         }
 
-        container.register(
-            SaveFoodRecordUseCase<
-                FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-            >.self
-        ) { resolver in
-            guard
-                let recordRepo = resolver.resolve(
-                    FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>.self)
-            else {
+        container.register(SaveFoodRecordUseCase.self) { resolver in
+            guard let recordRepo = resolver.resolve(FoodRecordRepositoryImpl.self) else {
                 fatalError("SaveFoodRecordUseCase dependencies not registered")
             }
             return SaveFoodRecordUseCase(repository: recordRepo)
         }
 
-        container.register(
-            FetchMonthlyCalendarDaysUseCase<
-                FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-            >.self
-        ) { resolver in
-            guard
-                let repository = resolver.resolve(
-                    FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>.self)
-            else {
+        container.register(FetchMonthlyCalendarDaysUseCase.self) { resolver in
+            guard let repository = resolver.resolve(FoodRecordRepositoryImpl.self) else {
                 fatalError("FoodRecordRepositoryImpl not registered")
             }
             return FetchMonthlyCalendarDaysUseCase(repository: repository)
         }
 
-        container.register(
-            FetchFoodRecordsUseCase<
-                FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-            >.self
-        ) { resolver in
-            guard
-                let repository = resolver.resolve(
-                    FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>.self)
-            else {
+        container.register(FetchFoodRecordsUseCase.self) { resolver in
+            guard let repository = resolver.resolve(FoodRecordRepositoryImpl.self) else {
                 fatalError("FoodRecordRepositoryImpl not registered")
             }
             return FetchFoodRecordsUseCase(repository: repository)
         }
 
-        container.register(
-            LoadWeeklyRecordUseCase<
-                FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>,
-                FoodImageAssetFetcher<TFLiteFoodClassifier, UIImageLoader>
-            >.self
-        ) { resolver in
-            guard
-                let recordRepo = resolver.resolve(
-                    FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>.self),
-                let fetchAssetUseCase = resolver.resolve(
-                    FetchFoodImageAssetUseCase<
-                        FoodImageAssetFetcher<TFLiteFoodClassifier, UIImageLoader>
-                    >.self
-                )
-            else {
+        container.register(LoadWeeklyRecordUseCase.self) { resolver in
+            guard let recordRepo = resolver.resolve(FoodRecordRepositoryImpl.self),
+                  let fetchAssetUseCase = resolver.resolve(FetchFoodImageAssetUseCase.self) else {
                 fatalError("LoadWeeklyRecordUseCase dependencies not registered")
             }
             return LoadWeeklyRecordUseCase(
@@ -335,37 +267,21 @@ extension SceneDelegate {
             )
         }
 
-        container.register(
-            UpdateFoodRecordUseCase<
-                FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-            >.self
-        ) { resolver in
-            guard
-                let repository = resolver.resolve(
-                    FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>.self)
-            else {
+        container.register(UpdateFoodRecordUseCase.self) { resolver in
+            guard let repository = resolver.resolve(FoodRecordRepositoryImpl.self) else {
                 fatalError("FoodRecordRepositoryImpl not registered")
             }
             return UpdateFoodRecordUseCase(repository: repository)
         }
 
-        container.register(
-            DeleteFoodRecordUseCase<
-                FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-            >.self
-        ) { resolver in
-            guard
-                let repository = resolver.resolve(
-                    FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>.self)
-            else {
+        container.register(DeleteFoodRecordUseCase.self) { resolver in
+            guard let repository = resolver.resolve(FoodRecordRepositoryImpl.self) else {
                 fatalError("FoodRecordRepositoryImpl not registered")
             }
             return DeleteFoodRecordUseCase(repository: repository)
         }
 
-        container.register(
-            SearchAddressUseCase<AddressSearchRepositoryImpl>.self
-        ) { resolver in
+        container.register(SearchAddressUseCase.self) { resolver in
             guard let addressRepo = resolver.resolve(AddressSearchRepositoryImpl.self) else {
                 fatalError("AddressSearchRepositoryImpl not registered")
             }
@@ -407,58 +323,32 @@ extension SceneDelegate {
             return WithdrawUserUseCase(authRepository: authRepository, loginSession: loginSession)
         }
 
-        container.register(
-            FetchInsightUseCase<
-                InsightRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-            >.self
-        ) { resolver in
-            guard let repository = resolver.resolve(
-                InsightRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>.self
-            ) else {
+        container.register(FetchInsightUseCase.self) { resolver in
+            guard let repository = resolver.resolve(InsightRepositoryImpl.self) else {
                 fatalError("FetchInsightUseCase dependencies not registered")
             }
             return FetchInsightUseCase(repository: repository)
         }
 
-        container.register(
-            FetchUserProfileUseCase<
-                UserRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>,
-                NicknameStorage
-            >.self
-        ) { resolver in
+        container.register(FetchUserProfileUseCase.self) { resolver in
             guard let repository = resolver.resolve(UserRepository.self),
-                  let concreteRepository = repository
-                      as? UserRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>,
-                  let nicknameStorage = resolver.resolve(NicknameStoring.self),
-                  let concreteNicknameStorage = nicknameStorage as? NicknameStorage
-            else {
-                fatalError("FetchUserProfileUseCase dependencies not registered or unexpected type")
+                  let nicknameStorage = resolver.resolve(NicknameStoring.self) else {
+                fatalError("FetchUserProfileUseCase dependencies not registered")
             }
-            return FetchUserProfileUseCase(
-                repository: concreteRepository,
-                nicknameStorage: concreteNicknameStorage
-            )
+            return FetchUserProfileUseCase(repository: repository, nicknameStorage: nicknameStorage)
         }
 
-        container.register(
-            UpdateDeviceNotificationSettingUseCase.self
-        ) { resolver in
+        container.register(UpdateDeviceNotificationSettingUseCase.self) { resolver in
             guard let repository = resolver.resolve(DeviceRepository.self),
                   let pushTokenProvider = resolver.resolve(PushTokenStoring.self),
                   let notificationAuthProvider = resolver.resolve(NotificationAuthorizationProviding.self),
                   let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
                 fatalError("UpdateDeviceNotificationSettingUseCase dependencies not registered")
             }
-
-            guard let concreteRepository = repository as? DeviceRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>> else {
-                fatalError("DeviceRepository is not of expected type")
-            }
-
             let deviceID = UIDevice.current.identifierForVendor?.uuidString
             let osVersion = UIDevice.current.systemVersion
-
             return UpdateDeviceNotificationSettingUseCase(
-                repository: concreteRepository,
+                repository: repository,
                 notificationAuthorizationProvider: notificationAuthProvider,
                 pushTokenProvider: pushTokenProvider,
                 appVersion: appVersion,
@@ -471,23 +361,14 @@ extension SceneDelegate {
     fileprivate func registerPresentation() {}
 
     fileprivate func makeAppFlowController() -> AppFlowController {
-        typealias RecordRepo = FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-        typealias AssetFetcher = FoodImageAssetFetcher<TFLiteFoodClassifier, UIImageLoader>
-
-        // Login
         guard let finalizeUseCase = try? container.resolve(FinalizeAppleLoginUseCase.self) else {
             fatalError("FinalizeAppleLoginUseCase not registered")
         }
 
-        // Insight
-        typealias FetchInsightUC = FetchInsightUseCase<
-            InsightRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-        >
-        guard let fetchInsightUseCase = try? container.resolve(FetchInsightUC.self) else {
+        guard let fetchInsightUseCase = try? container.resolve(FetchInsightUseCase.self) else {
             fatalError("FetchInsightUseCase not registered")
         }
 
-        // MyPage
         guard let updateDeviceUseCase = try? container.resolve(UpdateDeviceNotificationSettingUseCase.self),
               let notificationAuthProvider = try? container.resolve(NotificationAuthorizationProviding.self),
               let logoutUseCase = try? container.resolve(LogoutUseCase.self),
@@ -497,9 +378,7 @@ extension SceneDelegate {
             fatalError("MyPageSceneFactory dependencies not registered")
         }
 
-        // ImagePicker
-        typealias FetchImageAssetUC = FetchFoodImageAssetUseCase<AssetFetcher>
-        guard let fetchImageAssetUseCase = try? container.resolve(FetchImageAssetUC.self),
+        guard let fetchImageAssetUseCase = try? container.resolve(FetchFoodImageAssetUseCase.self),
               let imageProvider = try? container.resolve(UIImageLoader.self) else {
             fatalError("ImagePickerCoordinator dependencies not registered")
         }
@@ -509,33 +388,28 @@ extension SceneDelegate {
             fetchUseCase: fetchImageAssetUseCase
         )
 
-        // Detail
-        guard
-            let fetchRecordsUseCase = try? container.resolve(FetchFoodRecordsUseCase<RecordRepo>.self),
-            let saveFoodRecordUseCase = try? container.resolve(SaveFoodRecordUseCase<RecordRepo>.self),
-            let deleteFoodRecordUseCase = try? container.resolve(DeleteFoodRecordUseCase<RecordRepo>.self),
-            let pushNotificationObserver = try? container.resolve(PushNotificationObserver.self)
-        else {
+        guard let fetchRecordsUseCase = try? container.resolve(FetchFoodRecordsUseCase.self),
+              let saveFoodRecordUseCase = try? container.resolve(SaveFoodRecordUseCase.self),
+              let deleteFoodRecordUseCase = try? container.resolve(DeleteFoodRecordUseCase.self),
+              let pushNotificationObserver = try? container.resolve(PushNotificationObserver.self) else {
             fatalError("DetailSceneFactory dependencies not registered")
         }
 
-        // Edit
-        guard let updateFoodRecordUseCase = try? container.resolve(UpdateFoodRecordUseCase<RecordRepo>.self) else {
+        guard let updateFoodRecordUseCase = try? container.resolve(UpdateFoodRecordUseCase.self) else {
             fatalError("EditSceneFactory dependencies not registered")
         }
 
-        // AddressSearch
-        guard let searchAddressUseCase = try? container.resolve(SearchAddressUseCase<AddressSearchRepositoryImpl>.self) else {
+        guard let searchAddressUseCase = try? container.resolve(SearchAddressUseCase.self) else {
             fatalError("AddressSearchSceneFactory dependencies not registered")
         }
 
         // Calendar
         guard
-            let requestPhotoAuthUseCase = try? container.resolve(RequestPhotoAuthorizationUseCase<PhotoAuthorizationFetcher>.self),
-            let loadWeeklyUseCase = try? container.resolve(LoadWeeklyRecordUseCase<RecordRepo, AssetFetcher>.self),
+            let requestPhotoAuthUseCase = try? container.resolve(RequestPhotoAuthorizationUseCase.self),
+            let loadWeeklyUseCase = try? container.resolve(LoadWeeklyRecordUseCase.self),
             let coachmarkStorage = try? container.resolve(CoachmarkStoring.self),
             let checkAppReviewUseCase = try? container.resolve(CheckAppReviewEligibilityUseCase.self),
-            let fetchMonthlyUseCase = try? container.resolve(FetchMonthlyCalendarDaysUseCase<RecordRepo>.self)
+            let fetchMonthlyUseCase = try? container.resolve(FetchMonthlyCalendarDaysUseCase.self)
         else {
             fatalError("CalendarSceneFactory dependencies not registered")
         }

--- a/FoodDiary/Data/Sources/Core/FoodImageAsset/FoodImageAssetFetcher.swift
+++ b/FoodDiary/Data/Sources/Core/FoodImageAsset/FoodImageAssetFetcher.swift
@@ -11,12 +11,9 @@ import Photos
 import UIKit
 
 /// 사진 라이브러리에서 음식 사진을 시간순으로 가져오는 `Repository` 구현체
-public struct FoodImageAssetFetcher<
-    FoodClassifier: FoodClassifierRepresentable,
-    ImageRepo: RenderableImageRepository
->: FoodImageAssetRepository where ImageRepo.Asset == PHAsset {
-    private let foodClassifier: FoodClassifier
-    private let imageRepository: ImageRepo
+public struct FoodImageAssetFetcher: FoodImageAssetRepository {
+    private let foodClassifier: any FoodClassifierRepresentable
+    private let imageRepository: any RenderableImageRepository
     private let cache: ClassificationCacheManager
     private let imageTargetSize: CGSize
     private let logger = Logger(label: "com.fooddiary.asset-fetcher")
@@ -27,8 +24,8 @@ public struct FoodImageAssetFetcher<
     ///   - cache: 분류 결과 캐시
     ///   - imageTargetSize: ML 분류용 이미지 크기 (기본: 224x224)
     public init(
-        foodClassifier: FoodClassifier,
-        imageRepository: ImageRepo,
+        foodClassifier: any FoodClassifierRepresentable,
+        imageRepository: any RenderableImageRepository,
         cache: ClassificationCacheManager,
         imageTargetSize: CGSize = CGSize(width: 224, height: 224)
     ) {
@@ -41,7 +38,7 @@ public struct FoodImageAssetFetcher<
     public func fetchFoodImageAssets(
         from startDate: Date,
         to endDate: Date?
-    ) async throws -> [Date: [FoodImageAsset<PHAsset>]] {
+    ) async throws -> [Date: [FoodImageAsset]] {
         let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
         guard status == .authorized || status == .limited else {
             logger.error("[Asset Fetch] 사진 라이브러리 권한 없음 (status: \(status.rawValue))")
@@ -103,8 +100,6 @@ public struct FoodImageAssetFetcher<
     }
 }
 
-public typealias PHFoodImageAsset = FoodImageAsset<PHAsset>
-
 // MARK: - Photo Fetching
 
 extension FoodImageAssetFetcher {
@@ -150,7 +145,7 @@ extension FoodImageAssetFetcher {
 
 extension FoodImageAssetFetcher {
     fileprivate func classifyAllSections(_ sections: [PhotoSection]) async throws -> [Date:
-        [PHFoodImageAsset]]
+        [FoodImageAsset]]
     {
         let results = try await mapEach(sections) { section in
             let photos = try await self.classifyPhotosInSection(section)
@@ -161,7 +156,7 @@ extension FoodImageAssetFetcher {
     }
 
     fileprivate func classifyPhotosInSection(_ section: PhotoSection) async throws
-        -> [PHFoodImageAsset]
+        -> [FoodImageAsset]
     {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MM/dd"
@@ -170,7 +165,7 @@ extension FoodImageAssetFetcher {
         let start = clock.now
 
         return try await withThrowingTaskGroup(
-            of: (originalIndex: Int, photo: PHFoodImageAsset).self
+            of: (originalIndex: Int, photo: FoodImageAsset).self
         ) { group in
             for (index, asset) in section.assets.enumerated() {
                 group.addTask {
@@ -178,7 +173,7 @@ extension FoodImageAssetFetcher {
                 }
             }
 
-            var results: [(originalIndex: Int, photo: PHFoodImageAsset)] = []
+            var results: [(originalIndex: Int, photo: FoodImageAsset)] = []
             for try await result in group {
                 results.append(result)
             }
@@ -193,7 +188,7 @@ extension FoodImageAssetFetcher {
         }
     }
 
-    fileprivate func classifyAsset(_ asset: PHAsset) async throws -> PHFoodImageAsset {
+    fileprivate func classifyAsset(_ asset: PHAsset) async throws -> FoodImageAsset {
         let identifier = asset.localIdentifier
 
         if let cached = await cache.get(identifier) {

--- a/FoodDiary/Data/Sources/Core/TokenManager/AuthTokenStorage.swift
+++ b/FoodDiary/Data/Sources/Core/TokenManager/AuthTokenStorage.swift
@@ -9,11 +9,11 @@ import Foundation
 import Domain
 
 /// Keychain을 사용한 인증 토큰 저장소 구현체
-public struct AuthTokenStorage<Service: KeychainServicing>: AuthTokenStoring {
-    private let keychainService: Service
+public struct AuthTokenStorage: AuthTokenStoring {
+    private let keychainService: any KeychainServicing
     private let tokenKey = "access_token"
 
-    public init(keychainService: Service) {
+    public init(keychainService: any KeychainServicing) {
         self.keychainService = keychainService
     }
 

--- a/FoodDiary/Data/Sources/Core/TokenManager/KeychainServicing.swift
+++ b/FoodDiary/Data/Sources/Core/TokenManager/KeychainServicing.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol KeychainServicing {
+public protocol KeychainServicing: Sendable {
     func save(key: String, value: String) -> Bool
     func load(key: String) -> String?
     func delete(key: String) -> Bool

--- a/FoodDiary/Data/Sources/Network/HTTPClienting.swift
+++ b/FoodDiary/Data/Sources/Network/HTTPClienting.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol HTTPClienting {
+public protocol HTTPClienting: Sendable {
     func request<T: Decodable>(_ request: some Requestable, accessToken: String?) async throws -> T
     func request(_ request: some Requestable, accessToken: String?) async throws
 }

--- a/FoodDiary/Data/Sources/Repository/AuthRepository.swift
+++ b/FoodDiary/Data/Sources/Repository/AuthRepository.swift
@@ -8,11 +8,11 @@
 import Domain
 import Foundation
 
-public struct AuthRepositoryImpl<Storage: AuthTokenStoring, Client: HTTPClienting>: AuthRepository {
-    let httpClient: Client
-    let tokenStorage: Storage
+public struct AuthRepositoryImpl: AuthRepository {
+    let httpClient: any HTTPClienting
+    let tokenStorage: any AuthTokenStoring
 
-    public init(httpClient: Client, tokenStorage: Storage) {
+    public init(httpClient: any HTTPClienting, tokenStorage: any AuthTokenStoring) {
         self.httpClient = httpClient
         self.tokenStorage = tokenStorage
     }

--- a/FoodDiary/Data/Sources/Repository/DeviceRepositoryImpl.swift
+++ b/FoodDiary/Data/Sources/Repository/DeviceRepositoryImpl.swift
@@ -8,11 +8,11 @@
 import Domain
 import Foundation
 
-public struct DeviceRepositoryImpl<Client: HTTPClienting, Storage: AuthTokenStoring>: DeviceRepository {
-    private let httpClient: Client
-    private let tokenStorage: Storage
+public struct DeviceRepositoryImpl: DeviceRepository {
+    private let httpClient: any HTTPClienting
+    private let tokenStorage: any AuthTokenStoring
 
-    public init(httpClient: Client, tokenStorage: Storage) {
+    public init(httpClient: any HTTPClienting, tokenStorage: any AuthTokenStoring) {
         self.httpClient = httpClient
         self.tokenStorage = tokenStorage
     }

--- a/FoodDiary/Data/Sources/Repository/FoodRecordRepositoryImpl.swift
+++ b/FoodDiary/Data/Sources/Repository/FoodRecordRepositoryImpl.swift
@@ -9,12 +9,9 @@ import Photos
 import UIKit
 
 /// FoodRecordRepository 구현체
-public struct FoodRecordRepositoryImpl<
-    Client: HTTPClienting & Sendable,
-    Storage: AuthTokenStoring & Sendable
->: FoodRecordRepository {
-    private let httpClient: Client
-    private let tokenStorage: Storage
+public struct FoodRecordRepositoryImpl: FoodRecordRepository {
+    private let httpClient: any HTTPClienting
+    private let tokenStorage: any AuthTokenStoring
     private let deviceId: String
     private let imageConverter: PHAssetConverter
     private let calendar = Calendar.current
@@ -27,7 +24,7 @@ public struct FoodRecordRepositoryImpl<
     #endif
 
     public init(
-        httpClient: Client, tokenStorage: Storage, deviceId: String,
+        httpClient: any HTTPClienting, tokenStorage: any AuthTokenStoring, deviceId: String,
         imageConverter: PHAssetConverter
     ) {
         self.httpClient = httpClient

--- a/FoodDiary/Data/Sources/Repository/InsightRepositoryImpl.swift
+++ b/FoodDiary/Data/Sources/Repository/InsightRepositoryImpl.swift
@@ -6,11 +6,11 @@
 import Domain
 import Foundation
 
-public struct InsightRepositoryImpl<Client: HTTPClienting, Storage: AuthTokenStoring>: InsightRepository {
-    private let httpClient: Client
-    private let tokenStorage: Storage
+public struct InsightRepositoryImpl: InsightRepository {
+    private let httpClient: any HTTPClienting
+    private let tokenStorage: any AuthTokenStoring
 
-    public init(httpClient: Client, tokenStorage: Storage) {
+    public init(httpClient: any HTTPClienting, tokenStorage: any AuthTokenStoring) {
         self.httpClient = httpClient
         self.tokenStorage = tokenStorage
     }

--- a/FoodDiary/Data/Sources/Repository/TokenRepository.swift
+++ b/FoodDiary/Data/Sources/Repository/TokenRepository.swift
@@ -8,16 +8,12 @@
 import Domain
 import Foundation
 
-public struct TokenRepositoryImpl<
-    Client: HTTPClienting,
-    Storage: AuthTokenStoring,
-    LaunchStorage: InitialLaunchStoring
->: TokenRepository {
-    let httpClient: Client
-    let storage: Storage
-    let launchStorage: LaunchStorage
+public struct TokenRepositoryImpl: TokenRepository {
+    let httpClient: any HTTPClienting
+    let storage: any AuthTokenStoring
+    let launchStorage: any InitialLaunchStoring
 
-    public init(httpClient: Client, storage: Storage, launchStorage: LaunchStorage) {
+    public init(httpClient: any HTTPClienting, storage: any AuthTokenStoring, launchStorage: any InitialLaunchStoring) {
         self.httpClient = httpClient
         self.storage = storage
         self.launchStorage = launchStorage

--- a/FoodDiary/Data/Sources/Repository/UIImageLoader.swift
+++ b/FoodDiary/Data/Sources/Repository/UIImageLoader.swift
@@ -14,8 +14,11 @@ public struct UIImageLoader: RenderableImageRepository {
         self.imageConverter = imageLoader
     }
 
-    public func loadImage(for asset: PHAsset, targetSize: CGSize, preferFastDelivery: Bool) async throws -> UIImage {
+    public func loadImage(for asset: any ImageAssetable, targetSize: CGSize, preferFastDelivery: Bool) async throws -> UIImage {
+        guard let phAsset = asset as? PHAsset else {
+            throw FoodRecordError.imageConversionFailed
+        }
         let deliveryMode: PHImageRequestOptionsDeliveryMode = preferFastDelivery ? .fastFormat : .highQualityFormat
-        return try await imageConverter.convert(from: asset, targetSize: targetSize, deliveryMode: deliveryMode)
+        return try await imageConverter.convert(from: phAsset, targetSize: targetSize, deliveryMode: deliveryMode)
     }
 }

--- a/FoodDiary/Data/Sources/Repository/UserRepositoryImpl.swift
+++ b/FoodDiary/Data/Sources/Repository/UserRepositoryImpl.swift
@@ -8,11 +8,11 @@
 import Domain
 import Foundation
 
-public struct UserRepositoryImpl<Client: HTTPClienting, Storage: AuthTokenStoring>: UserRepository {
-    private let httpClient: Client
-    private let tokenStorage: Storage
+public struct UserRepositoryImpl: UserRepository {
+    private let httpClient: any HTTPClienting
+    private let tokenStorage: any AuthTokenStoring
 
-    public init(httpClient: Client, tokenStorage: Storage) {
+    public init(httpClient: any HTTPClienting, tokenStorage: any AuthTokenStoring) {
         self.httpClient = httpClient
         self.tokenStorage = tokenStorage
     }

--- a/FoodDiary/Domain/Sources/Core/InitialLaunch/InitialLaunchStoring.swift
+++ b/FoodDiary/Domain/Sources/Core/InitialLaunch/InitialLaunchStoring.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol InitialLaunchStoring {
+public protocol InitialLaunchStoring: Sendable {
     func get() -> Bool
     func set()
 }

--- a/FoodDiary/Domain/Sources/Core/TokenManager/AuthTokenStoring.swift
+++ b/FoodDiary/Domain/Sources/Core/TokenManager/AuthTokenStoring.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// 인증 토큰(Access Token)을 저장하고 관리하는 프로토콜
-public protocol AuthTokenStoring {
+public protocol AuthTokenStoring: Sendable {
     /// 저장된 인증 토큰을 가져옴
     /// - Returns: 인증 토큰 문자열, 없을 경우 nil
     func get() -> String?

--- a/FoodDiary/Domain/Sources/Entity/FoodImageAsset.swift
+++ b/FoodDiary/Domain/Sources/Entity/FoodImageAsset.swift
@@ -7,15 +7,15 @@
 
 import Foundation
 
-public struct FoodImageAsset<ImageAsset: ImageAssetable>: Sendable, Equatable {
-    public let imageAsset: ImageAsset
+public struct FoodImageAsset: Sendable, Equatable {
+    public let imageAsset: any ImageAssetable
     /// 음식일 확률 (0.0 ~ 1.0)
     public let foodProbability: Float
 
     public var id: String { imageAsset.id }
     public var creationDate: Date? { imageAsset.creationDate }
 
-    public init(imageAsset: ImageAsset, foodProbability: Float) {
+    public init(imageAsset: any ImageAssetable, foodProbability: Float) {
         self.imageAsset = imageAsset
         self.foodProbability = foodProbability
     }

--- a/FoodDiary/Domain/Sources/Repository/FoodImageAssetRepository.swift
+++ b/FoodDiary/Domain/Sources/Repository/FoodImageAssetRepository.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 public protocol FoodImageAssetRepository: Sendable {
-    associatedtype Asset: ImageAssetable
-
     /// 날짜별 음식 사진 조회 (음식 확률 순 정렬)
     /// - Parameters:
     ///   - startDate: 조회 시작 날짜 (필수)
@@ -18,7 +16,7 @@ public protocol FoodImageAssetRepository: Sendable {
     func fetchFoodImageAssets(
         from startDate: Date,
         to endDate: Date?
-    ) async throws -> [Date: [FoodImageAsset<Asset>]]
+    ) async throws -> [Date: [FoodImageAsset]]
 
     /// 현재 주 + 과거 N주 범위의 사진 데이터를 백그라운드에서 미리 로드하여 캐시 워밍
     /// - Parameters:

--- a/FoodDiary/Domain/Sources/Repository/RenderableImageRepository.swift
+++ b/FoodDiary/Domain/Sources/Repository/RenderableImageRepository.swift
@@ -6,20 +6,18 @@
 import UIKit
 
 /// 이미지 로딩을 담당하는 Repository 프로토콜
-public protocol RenderableImageRepository<Asset>: Sendable {
-    associatedtype Asset: ImageAssetable
-
+public protocol RenderableImageRepository: Sendable {
     /// 지정된 Asset의 이미지를 로드합니다.
     /// - Parameters:
     ///   - asset: 이미지 에셋
     ///   - targetSize: 요청 이미지 크기
     ///   - preferFastDelivery: true이면 품질보다 속도를 우선합니다 (ML 전처리 등)
     /// - Returns: 로드된 UIImage
-    func loadImage(for asset: Asset, targetSize: CGSize, preferFastDelivery: Bool) async throws -> UIImage
+    func loadImage(for asset: any ImageAssetable, targetSize: CGSize, preferFastDelivery: Bool) async throws -> UIImage
 }
 
 extension RenderableImageRepository {
-    public func loadImage(for asset: Asset, targetSize: CGSize) async throws -> UIImage {
+    public func loadImage(for asset: any ImageAssetable, targetSize: CGSize) async throws -> UIImage {
         try await loadImage(for: asset, targetSize: targetSize, preferFastDelivery: false)
     }
 }

--- a/FoodDiary/Domain/Sources/UseCase/DeleteFoodRecordUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/DeleteFoodRecordUseCase.swift
@@ -5,10 +5,10 @@
 
 import Foundation
 
-public struct DeleteFoodRecordUseCase<Repository: FoodRecordRepository>: Sendable {
-    private let repository: Repository
+public struct DeleteFoodRecordUseCase: Sendable {
+    private let repository: any FoodRecordRepository
 
-    public init(repository: Repository) {
+    public init(repository: any FoodRecordRepository) {
         self.repository = repository
     }
 

--- a/FoodDiary/Domain/Sources/UseCase/FetchFoodImageAssetUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/FetchFoodImageAssetUseCase.swift
@@ -7,10 +7,10 @@
 
 import Foundation
 
-public struct FetchFoodImageAssetUseCase<Repository: FoodImageAssetRepository> {
-    private let repository: Repository
+public struct FetchFoodImageAssetUseCase {
+    private let repository: any FoodImageAssetRepository
 
-    public init(repository: Repository) {
+    public init(repository: any FoodImageAssetRepository) {
         self.repository = repository
     }
 
@@ -18,7 +18,7 @@ public struct FetchFoodImageAssetUseCase<Repository: FoodImageAssetRepository> {
         from startDate: Date,
         to endDate: Date?,
         priority: TaskPriority = .utility
-    ) async throws -> [Date: [FoodImageAsset<Repository.Asset>]] {
+    ) async throws -> [Date: [FoodImageAsset]] {
         try await Task(priority: priority) {
             try await repository.fetchFoodImageAssets(from: startDate, to: endDate)
         }.value

--- a/FoodDiary/Domain/Sources/UseCase/FetchFoodRecordsUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/FetchFoodRecordsUseCase.swift
@@ -6,10 +6,10 @@
 import Foundation
 
 /// 특정 날짜의 음식 기록 조회 UseCase
-public struct FetchFoodRecordsUseCase<Repository: FoodRecordRepository>: Sendable {
-    private let repository: Repository
+public struct FetchFoodRecordsUseCase: Sendable {
+    private let repository: any FoodRecordRepository
 
-    public init(repository: Repository) {
+    public init(repository: any FoodRecordRepository) {
         self.repository = repository
     }
 

--- a/FoodDiary/Domain/Sources/UseCase/FetchInsightUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/FetchInsightUseCase.swift
@@ -5,10 +5,10 @@
 
 import Foundation
 
-public struct FetchInsightUseCase<Repository: InsightRepository> {
-    private let repository: Repository
+public struct FetchInsightUseCase {
+    private let repository: any InsightRepository
 
-    public init(repository: Repository) {
+    public init(repository: any InsightRepository) {
         self.repository = repository
     }
 

--- a/FoodDiary/Domain/Sources/UseCase/FetchMonthlyCalendarDaysUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/FetchMonthlyCalendarDaysUseCase.swift
@@ -6,10 +6,10 @@
 import Foundation
 
 /// 월간 캘린더 데이터 조회 UseCase
-public struct FetchMonthlyCalendarDaysUseCase<Repository: FoodRecordRepository>: Sendable {
-    private let repository: Repository
+public struct FetchMonthlyCalendarDaysUseCase: Sendable {
+    private let repository: any FoodRecordRepository
 
-    public init(repository: Repository) {
+    public init(repository: any FoodRecordRepository) {
         self.repository = repository
     }
 

--- a/FoodDiary/Domain/Sources/UseCase/FetchUserProfileUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/FetchUserProfileUseCase.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-public struct FetchUserProfileUseCase<Repository: UserRepository, Storage: NicknameStoring> {
-    private let repository: Repository
-    private let nicknameStorage: Storage
+public struct FetchUserProfileUseCase {
+    private let repository: any UserRepository
+    private let nicknameStorage: any NicknameStoring
 
-    public init(repository: Repository, nicknameStorage: Storage) {
+    public init(repository: any UserRepository, nicknameStorage: any NicknameStoring) {
         self.repository = repository
         self.nicknameStorage = nicknameStorage
     }

--- a/FoodDiary/Domain/Sources/UseCase/LoadWeeklyRecordUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/LoadWeeklyRecordUseCase.swift
@@ -6,10 +6,7 @@
 import Foundation
 
 /// 주간 캘린더 데이터 로딩을 담당하는 UseCase
-public struct LoadWeeklyRecordUseCase<
-    RecordRepo: FoodRecordRepository,
-    AssetRepo: FoodImageAssetRepository
->: Sendable {
+public struct LoadWeeklyRecordUseCase: Sendable {
     public struct WeekData: Sendable {
         public let weekDays: [WeeklyCalendarDay]
         public let monthText: String
@@ -21,11 +18,11 @@ public struct LoadWeeklyRecordUseCase<
     }
 
     public struct DateData: Sendable {
-        public let photos: [FoodImageAsset<AssetRepo.Asset>]
+        public let photos: [FoodImageAsset]
         public let records: [FoodRecord]
         public let startOfDay: Date
 
-        public init(photos: [FoodImageAsset<AssetRepo.Asset>], records: [FoodRecord], startOfDay: Date) {
+        public init(photos: [FoodImageAsset], records: [FoodRecord], startOfDay: Date) {
             self.photos = photos
             self.records = records
             self.startOfDay = startOfDay
@@ -33,13 +30,13 @@ public struct LoadWeeklyRecordUseCase<
     }
 
     private let calendar: Calendar
-    private let recordRepository: RecordRepo
-    private let fetchFoodImageAssetUseCase: FetchFoodImageAssetUseCase<AssetRepo>
+    private let recordRepository: any FoodRecordRepository
+    private let fetchFoodImageAssetUseCase: FetchFoodImageAssetUseCase
 
     public init(
         calendar: Calendar,
-        recordRepository: RecordRepo,
-        fetchFoodImageAssetUseCase: FetchFoodImageAssetUseCase<AssetRepo>
+        recordRepository: any FoodRecordRepository,
+        fetchFoodImageAssetUseCase: FetchFoodImageAssetUseCase
     ) {
         self.calendar = calendar
         self.recordRepository = recordRepository
@@ -75,7 +72,7 @@ public struct LoadWeeklyRecordUseCase<
     }
 
     /// 특정 날짜의 사진만 로드
-    public func loadPhotos(for date: Date) async throws -> [FoodImageAsset<AssetRepo.Asset>] {
+    public func loadPhotos(for date: Date) async throws -> [FoodImageAsset] {
         let startOfDay = calendar.startOfDay(for: date)
         let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)
 

--- a/FoodDiary/Domain/Sources/UseCase/RequestPhotoAuthorizationUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/RequestPhotoAuthorizationUseCase.swift
@@ -5,10 +5,10 @@
 
 import Foundation
 
-public struct RequestPhotoAuthorizationUseCase<Repository: PhotoAuthorizationRepository> {
-    private let repository: Repository
+public struct RequestPhotoAuthorizationUseCase {
+    private let repository: any PhotoAuthorizationRepository
 
-    public init(repository: Repository) {
+    public init(repository: any PhotoAuthorizationRepository) {
         self.repository = repository
     }
 

--- a/FoodDiary/Domain/Sources/UseCase/SaveFoodRecordUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/SaveFoodRecordUseCase.swift
@@ -7,13 +7,11 @@ import Foundation
 
 /// Asset을 서버에 업로드하는 UseCase
 /// 분석 결과는 Remote Push로 수신
-public struct SaveFoodRecordUseCase<
-    RecordRepo: FoodRecordRepository
->: Sendable {
-    private let repository: RecordRepo
+public struct SaveFoodRecordUseCase: Sendable {
+    private let repository: any FoodRecordRepository
 
     public init(
-        repository: RecordRepo
+        repository: any FoodRecordRepository
     ) {
         self.repository = repository
     }

--- a/FoodDiary/Domain/Sources/UseCase/SearchAddressUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/SearchAddressUseCase.swift
@@ -5,10 +5,10 @@
 
 import Foundation
 
-public struct SearchAddressUseCase<Repository: AddressSearchRepository>: Sendable {
-    private let repository: Repository
+public struct SearchAddressUseCase: Sendable {
+    private let repository: any AddressSearchRepository
 
-    public init(repository: Repository) {
+    public init(repository: any AddressSearchRepository) {
         self.repository = repository
     }
 

--- a/FoodDiary/Domain/Sources/UseCase/UpdateFoodRecordUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/UpdateFoodRecordUseCase.swift
@@ -5,10 +5,10 @@
 
 import Foundation
 
-public struct UpdateFoodRecordUseCase<Repository: FoodRecordRepository>: Sendable {
-    private let repository: Repository
+public struct UpdateFoodRecordUseCase: Sendable {
+    private let repository: any FoodRecordRepository
 
-    public init(repository: Repository) {
+    public init(repository: any FoodRecordRepository) {
         self.repository = repository
     }
 

--- a/FoodDiary/Domain/Sources/UseCase/ValidateAccessTokenUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/ValidateAccessTokenUseCase.swift
@@ -7,10 +7,10 @@
 
 import Foundation
 
-public struct ValidateAccessTokenUseCase<Repository: TokenRepository> {
-    private let repository: Repository
-    
-    public init(repository: Repository) {
+public struct ValidateAccessTokenUseCase {
+    private let repository: any TokenRepository
+
+    public init(repository: any TokenRepository) {
         self.repository = repository
     }
     

--- a/FoodDiary/Domain/Tests/FoodImageAssetFetchUseCaseTests.swift
+++ b/FoodDiary/Domain/Tests/FoodImageAssetFetchUseCaseTests.swift
@@ -68,7 +68,7 @@ private func createMockFoodImageAssets(
     startIndex: Int = 0,
     count: Int,
     probabilities: [Float]
-) -> [FoodImageAsset<MockImageAssetable>] {
+) -> [FoodImageAsset] {
     (0..<count).map { index in
         FoodImageAsset(
             imageAsset: MockImageAssetable(

--- a/FoodDiary/Domain/Tests/Mock/MockFoodImageAssetRepository.swift
+++ b/FoodDiary/Domain/Tests/Mock/MockFoodImageAssetRepository.swift
@@ -9,11 +9,9 @@
 import Foundation
 
 final class MockFoodImageAssetRepository: FoodImageAssetRepository, @unchecked Sendable {
-    typealias Asset = MockImageAssetable
+    var resultToReturn: [Date: [FoodImageAsset]] = [:]
 
-    var resultToReturn: [Date: [FoodImageAsset<MockImageAssetable>]] = [:]
-
-    func fetchFoodImageAssets(from startDate: Date, to endDate: Date?) async throws -> [Date: [FoodImageAsset<MockImageAssetable>]] {
+    func fetchFoodImageAssets(from startDate: Date, to endDate: Date?) async throws -> [Date: [FoodImageAsset]] {
         resultToReturn
     }
 

--- a/FoodDiary/Presentation/Sources/AddressSearch/AddressSearchViewController.swift
+++ b/FoodDiary/Presentation/Sources/AddressSearch/AddressSearchViewController.swift
@@ -23,13 +23,11 @@ enum AddressSearchConstants {
     static let resultCellHeight: CGFloat = 72
 }
 
-public final class AddressSearchViewController<
-    AddressRepo: AddressSearchRepository
->: UIViewController, UITextFieldDelegate {
+public final class AddressSearchViewController: UIViewController, UITextFieldDelegate {
 
     // MARK: - Dependencies
 
-    private let viewModel: AddressSearchViewModel<AddressRepo>
+    private let viewModel: AddressSearchViewModel
     private let onAddressSelected: ((AddressSearchResult) -> Void)?
     private var cancellables = Set<AnyCancellable>()
 
@@ -114,7 +112,7 @@ public final class AddressSearchViewController<
     // MARK: - Init
 
     public init(
-        viewModel: AddressSearchViewModel<AddressRepo>,
+        viewModel: AddressSearchViewModel,
         onAddressSelected: ((AddressSearchResult) -> Void)?
     ) {
         self.viewModel = viewModel
@@ -233,7 +231,7 @@ public final class AddressSearchViewController<
 
     // MARK: - Private Methods
 
-    private func updateUI(with state: AddressSearchViewModel<AddressRepo>.State) {
+    private func updateUI(with state: AddressSearchViewModel.State) {
         let displayResults: [AddressSearchResult]
 
         switch state.mode {
@@ -268,7 +266,7 @@ public final class AddressSearchViewController<
         }
     }
 
-    private func handleEvent(_ event: AddressSearchViewModel<AddressRepo>.Event) {
+    private func handleEvent(_ event: AddressSearchViewModel.Event) {
         switch event {
         case .addressSelected(let result):
             onAddressSelected?(result)

--- a/FoodDiary/Presentation/Sources/AddressSearch/AddressSearchViewModel.swift
+++ b/FoodDiary/Presentation/Sources/AddressSearch/AddressSearchViewModel.swift
@@ -7,7 +7,7 @@ import Combine
 import Domain
 import Foundation
 
-public final class AddressSearchViewModel<AddressRepo: AddressSearchRepository> {
+public final class AddressSearchViewModel {
 
     // MARK: - Output
 
@@ -28,13 +28,13 @@ public final class AddressSearchViewModel<AddressRepo: AddressSearchRepository> 
     private let stateSubject: CurrentValueSubject<State, Never>
     private let eventSubject = PassthroughSubject<Event, Never>()
     private var cancellables = Set<AnyCancellable>()
-    private let searchAddressUseCase: SearchAddressUseCase<AddressRepo>
+    private let searchAddressUseCase: SearchAddressUseCase
     private let diaryId: Int
 
     // MARK: - Init
 
     public init(
-        searchAddressUseCase: SearchAddressUseCase<AddressRepo>,
+        searchAddressUseCase: SearchAddressUseCase,
         diaryId: Int
     ) {
         self.searchAddressUseCase = searchAddressUseCase

--- a/FoodDiary/Presentation/Sources/AddressSearch/Coordinator/AddressSearchCoordinator.swift
+++ b/FoodDiary/Presentation/Sources/AddressSearch/Coordinator/AddressSearchCoordinator.swift
@@ -31,7 +31,7 @@ public final class AddressSearchCoordinator: Coordinator {
 // MARK: - Screen Routing
 
 private extension AddressSearchCoordinator {
-    func flowBind(vc: AddressSearchViewController<AddressSearchRepositoryImpl>) {
+    func flowBind(vc: AddressSearchViewController) {
         vc.flowPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in

--- a/FoodDiary/Presentation/Sources/AddressSearch/Coordinator/AddressSearchSceneFactory.swift
+++ b/FoodDiary/Presentation/Sources/AddressSearch/Coordinator/AddressSearchSceneFactory.swift
@@ -10,13 +10,13 @@ import UIKit
 // MARK: - Factory
 
 public final class AddressSearchSceneFactory {
-    private let searchAddressUseCase: SearchAddressUseCase<AddressSearchRepositoryImpl>
+    private let searchAddressUseCase: SearchAddressUseCase
 
-    public init(searchAddressUseCase: SearchAddressUseCase<AddressSearchRepositoryImpl>) {
+    public init(searchAddressUseCase: SearchAddressUseCase) {
         self.searchAddressUseCase = searchAddressUseCase
     }
 
-    public func makeScene(input: AddressSearchSceneInput) -> AddressSearchViewController<AddressSearchRepositoryImpl> {
+    public func makeScene(input: AddressSearchSceneInput) -> AddressSearchViewController {
         let viewModel = AddressSearchViewModel(
             searchAddressUseCase: searchAddressUseCase,
             diaryId: input.diaryId

--- a/FoodDiary/Presentation/Sources/Calendar/Coordinator/CalendarSceneFactory.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/Coordinator/CalendarSceneFactory.swift
@@ -8,32 +8,26 @@ import Domain
 import UIKit
 
 public final class CalendarSceneFactory {
-    private typealias RecordRepo = FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-    private typealias AssetFetcher = FoodImageAssetFetcher<TFLiteFoodClassifier, UIImageLoader>
-
-    private let requestPhotoAuthorizationUseCase: RequestPhotoAuthorizationUseCase<PhotoAuthorizationFetcher>
-    private let loadWeeklyCalendarDataUseCase: LoadWeeklyRecordUseCase<RecordRepo, AssetFetcher>
-    private let saveFoodRecordUseCase: SaveFoodRecordUseCase<RecordRepo>
+    private let requestPhotoAuthorizationUseCase: RequestPhotoAuthorizationUseCase
+    private let loadWeeklyCalendarDataUseCase: LoadWeeklyRecordUseCase
+    private let saveFoodRecordUseCase: SaveFoodRecordUseCase
     private let pushNotificationObserver: PushNotificationObserver
     private let getNicknameUseCase: GetNicknameUseCase
     private let coachmarkStorage: any CoachmarkStoring
     private let checkAppReviewEligibilityUseCase: CheckAppReviewEligibilityUseCase
-    private let fetchMonthlyCalendarDaysUseCase: FetchMonthlyCalendarDaysUseCase<RecordRepo>
-    private let fetchFoodRecordsUseCase: FetchFoodRecordsUseCase<RecordRepo>
+    private let fetchMonthlyCalendarDaysUseCase: FetchMonthlyCalendarDaysUseCase
+    private let fetchFoodRecordsUseCase: FetchFoodRecordsUseCase
 
     public init(
-        requestPhotoAuthorizationUseCase: RequestPhotoAuthorizationUseCase<PhotoAuthorizationFetcher>,
-        loadWeeklyCalendarDataUseCase: LoadWeeklyRecordUseCase<
-            FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>,
-            FoodImageAssetFetcher<TFLiteFoodClassifier, UIImageLoader>
-        >,
-        saveFoodRecordUseCase: SaveFoodRecordUseCase<FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>,
+        requestPhotoAuthorizationUseCase: RequestPhotoAuthorizationUseCase,
+        loadWeeklyCalendarDataUseCase: LoadWeeklyRecordUseCase,
+        saveFoodRecordUseCase: SaveFoodRecordUseCase,
         pushNotificationObserver: PushNotificationObserver,
         getNicknameUseCase: GetNicknameUseCase,
         coachmarkStorage: any CoachmarkStoring,
         checkAppReviewEligibilityUseCase: CheckAppReviewEligibilityUseCase,
-        fetchMonthlyCalendarDaysUseCase: FetchMonthlyCalendarDaysUseCase<FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>,
-        fetchFoodRecordsUseCase: FetchFoodRecordsUseCase<FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>
+        fetchMonthlyCalendarDaysUseCase: FetchMonthlyCalendarDaysUseCase,
+        fetchFoodRecordsUseCase: FetchFoodRecordsUseCase
     ) {
         self.requestPhotoAuthorizationUseCase = requestPhotoAuthorizationUseCase
         self.loadWeeklyCalendarDataUseCase = loadWeeklyCalendarDataUseCase

--- a/FoodDiary/Presentation/Sources/Calendar/MonthlyCalendar/MonthlyCalendarViewController.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/MonthlyCalendar/MonthlyCalendarViewController.swift
@@ -10,10 +10,7 @@ import Domain
 import SnapKit
 import UIKit
 
-public final class MonthlyCalendarViewController<
-    RecordRepo: FoodRecordRepository,
-    AuthRepo: PhotoAuthorizationRepository
->: UIViewController, UICollectionViewDelegate {
+public final class MonthlyCalendarViewController: UIViewController, UICollectionViewDelegate {
 
     private enum Section: Hashable {
         case calendar
@@ -21,7 +18,7 @@ public final class MonthlyCalendarViewController<
 
     // MARK: - Dependencies
 
-    private let viewModel: MonthlyCalendarViewModel<RecordRepo, AuthRepo>
+    private let viewModel: MonthlyCalendarViewModel
 
     // MARK: - Flow
 
@@ -75,7 +72,7 @@ public final class MonthlyCalendarViewController<
     // MARK: - Init
 
     public init(
-        viewModel: MonthlyCalendarViewModel<RecordRepo, AuthRepo>
+        viewModel: MonthlyCalendarViewModel
     ) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)

--- a/FoodDiary/Presentation/Sources/Calendar/MonthlyCalendar/ViewModel/MonthlyCalendarViewModel.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/MonthlyCalendar/ViewModel/MonthlyCalendarViewModel.swift
@@ -7,10 +7,7 @@ import Combine
 import Domain
 import Foundation
 
-public final class MonthlyCalendarViewModel<
-    RecordRepo: FoodRecordRepository,
-    AuthRepo: PhotoAuthorizationRepository
-> {
+public final class MonthlyCalendarViewModel {
     // MARK: - Output
 
     var statePublisher: AnyPublisher<State, Never> {
@@ -41,17 +38,17 @@ public final class MonthlyCalendarViewModel<
 
     // MARK: - Dependencies
 
-    private let fetchMonthlyCalendarDaysUseCase: FetchMonthlyCalendarDaysUseCase<RecordRepo>
-    private let requestPhotoAuthorizationUseCase: RequestPhotoAuthorizationUseCase<AuthRepo>
-    private let fetchFoodRecordsUseCase: FetchFoodRecordsUseCase<RecordRepo>
+    private let fetchMonthlyCalendarDaysUseCase: FetchMonthlyCalendarDaysUseCase
+    private let requestPhotoAuthorizationUseCase: RequestPhotoAuthorizationUseCase
+    private let fetchFoodRecordsUseCase: FetchFoodRecordsUseCase
     private let getNicknameUseCase: GetNicknameUseCase
 
     // MARK: - Init
 
     public init(
-        fetchMonthlyCalendarDaysUseCase: FetchMonthlyCalendarDaysUseCase<RecordRepo>,
-        requestPhotoAuthorizationUseCase: RequestPhotoAuthorizationUseCase<AuthRepo>,
-        fetchFoodRecordsUseCase: FetchFoodRecordsUseCase<RecordRepo>,
+        fetchMonthlyCalendarDaysUseCase: FetchMonthlyCalendarDaysUseCase,
+        requestPhotoAuthorizationUseCase: RequestPhotoAuthorizationUseCase,
+        fetchFoodRecordsUseCase: FetchFoodRecordsUseCase,
         getNicknameUseCase: GetNicknameUseCase
     ) {
         self.fetchMonthlyCalendarDaysUseCase = fetchMonthlyCalendarDaysUseCase

--- a/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/ViewModel/WeeklyCalendarViewModel.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/ViewModel/WeeklyCalendarViewModel.swift
@@ -10,12 +10,7 @@ import UIKit
 
 // MARK: - ViewModel
 
-public final class WeeklyCalendarViewModel<
-    RecordRepo: FoodRecordRepository,
-    AssetRepo: FoodImageAssetRepository,
-    AuthRepo: PhotoAuthorizationRepository,
-    PushObserver: PushNotificationObserving
-> {
+public final class WeeklyCalendarViewModel {
     // MARK: - Output
 
     public var statePublisher: AnyPublisher<State, Never> {
@@ -45,10 +40,10 @@ public final class WeeklyCalendarViewModel<
 
     // MARK: - Dependencies
 
-    private let requestPhotoAuthorizationUseCase: RequestPhotoAuthorizationUseCase<AuthRepo>
-    private let loadWeeklyCalendarDataUseCase: LoadWeeklyRecordUseCase<RecordRepo, AssetRepo>
-    private let saveFoodRecordUseCase: SaveFoodRecordUseCase<RecordRepo>
-    private let pushNotificationObserver: PushObserver
+    private let requestPhotoAuthorizationUseCase: RequestPhotoAuthorizationUseCase
+    private let loadWeeklyCalendarDataUseCase: LoadWeeklyRecordUseCase
+    private let saveFoodRecordUseCase: SaveFoodRecordUseCase
+    private let pushNotificationObserver: any PushNotificationObserving
     private let getNicknameUseCase: GetNicknameUseCase
     private let coachmarkStorage: any CoachmarkStoring
     private let checkAppReviewEligibilityUseCase: CheckAppReviewEligibilityUseCase
@@ -56,10 +51,10 @@ public final class WeeklyCalendarViewModel<
     // MARK: - Init
 
     public init(
-        requestPhotoAuthorizationUseCase: RequestPhotoAuthorizationUseCase<AuthRepo>,
-        loadWeeklyCalendarDataUseCase: LoadWeeklyRecordUseCase<RecordRepo, AssetRepo>,
-        saveFoodRecordUseCase: SaveFoodRecordUseCase<RecordRepo>,
-        pushNotificationObserver: PushObserver,
+        requestPhotoAuthorizationUseCase: RequestPhotoAuthorizationUseCase,
+        loadWeeklyCalendarDataUseCase: LoadWeeklyRecordUseCase,
+        saveFoodRecordUseCase: SaveFoodRecordUseCase,
+        pushNotificationObserver: any PushNotificationObserving,
         getNicknameUseCase: GetNicknameUseCase,
         coachmarkStorage: any CoachmarkStoring,
         checkAppReviewEligibilityUseCase: CheckAppReviewEligibilityUseCase
@@ -234,7 +229,7 @@ public final class WeeklyCalendarViewModel<
     }
 
     @MainActor
-    private func savePhotosAsRecord(_ assets: [AssetRepo.Asset]) async {
+    private func savePhotosAsRecord(_ assets: [any ImageAssetable]) async {
         guard !assets.isEmpty else { return }
 
         do {
@@ -337,7 +332,7 @@ extension WeeklyCalendarViewModel {
         case goToPreviousWeek
         case goToNextWeek
         case selectDate(Date)
-        case saveSelectedPhotos([AssetRepo.Asset])
+        case saveSelectedPhotos([any ImageAssetable])
         case handlePushNotification(AnalysisResultNotification)
         case refreshData(Date? = nil)
         case viewDidAppear

--- a/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/WeeklyCalendarViewController.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/WeeklyCalendarViewController.swift
@@ -14,16 +14,11 @@ private enum Constants {
     static let horizontalInset: CGFloat = 20
 }
 
-public final class WeeklyCalendarViewController<
-    RecordRepo: FoodRecordRepository,
-    AssetRepo: FoodImageAssetRepository,
-    AuthRepo: PhotoAuthorizationRepository,
-    PushObserver: PushNotificationObserving
->: UIViewController {
+public final class WeeklyCalendarViewController: UIViewController {
 
     // MARK: - Dependencies
 
-    private let viewModel: WeeklyCalendarViewModel<RecordRepo, AssetRepo, AuthRepo, PushObserver>
+    private let viewModel: WeeklyCalendarViewModel
 
     // MARK: - Flow
 
@@ -61,7 +56,7 @@ public final class WeeklyCalendarViewController<
     // MARK: - Init
 
     public init(
-        viewModel: WeeklyCalendarViewModel<RecordRepo, AssetRepo, AuthRepo, PushObserver>
+        viewModel: WeeklyCalendarViewModel
     ) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -285,8 +280,7 @@ public final class WeeklyCalendarViewController<
         let date = viewModel.state.selectedDate
         flowSubject.send(.pushImagePicker(
             ImagePickerSceneInput(date: date) { [weak self] assets in
-                let typed = assets.compactMap { $0 as? AssetRepo.Asset }
-                self?.viewModel.input.send(.saveSelectedPhotos(typed))
+                self?.viewModel.input.send(.saveSelectedPhotos(assets))
             }
         ))
     }

--- a/FoodDiary/Presentation/Sources/Detail/Coordinator/DetailCoordinator.swift
+++ b/FoodDiary/Presentation/Sources/Detail/Coordinator/DetailCoordinator.swift
@@ -31,7 +31,7 @@ public final class DetailCoordinator: Coordinator {
 // MARK: - Screen Routing
 
 private extension DetailCoordinator {
-    func flowBind(vc: DetailViewController<FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>, PushNotificationObserver>) {
+    func flowBind(vc: DetailViewController) {
         vc.flowPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in

--- a/FoodDiary/Presentation/Sources/Detail/Coordinator/DetailSceneFactory.swift
+++ b/FoodDiary/Presentation/Sources/Detail/Coordinator/DetailSceneFactory.swift
@@ -8,17 +8,15 @@ import Domain
 import UIKit
 
 public final class DetailSceneFactory {
-    private typealias RecordRepo = FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-
-    private let fetchRecordsUseCase: FetchFoodRecordsUseCase<RecordRepo>
-    private let saveFoodRecordUseCase: SaveFoodRecordUseCase<RecordRepo>
-    private let deleteFoodRecordUseCase: DeleteFoodRecordUseCase<RecordRepo>
+    private let fetchRecordsUseCase: FetchFoodRecordsUseCase
+    private let saveFoodRecordUseCase: SaveFoodRecordUseCase
+    private let deleteFoodRecordUseCase: DeleteFoodRecordUseCase
     private let pushNotificationObserver: PushNotificationObserver
 
     public init(
-        fetchRecordsUseCase: FetchFoodRecordsUseCase<FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>,
-        saveFoodRecordUseCase: SaveFoodRecordUseCase<FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>,
-        deleteFoodRecordUseCase: DeleteFoodRecordUseCase<FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>,
+        fetchRecordsUseCase: FetchFoodRecordsUseCase,
+        saveFoodRecordUseCase: SaveFoodRecordUseCase,
+        deleteFoodRecordUseCase: DeleteFoodRecordUseCase,
         pushNotificationObserver: PushNotificationObserver
     ) {
         self.fetchRecordsUseCase = fetchRecordsUseCase
@@ -27,10 +25,7 @@ public final class DetailSceneFactory {
         self.pushNotificationObserver = pushNotificationObserver
     }
 
-    public func makeScene(input: DetailSceneInput) -> DetailViewController<
-        FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>,
-        PushNotificationObserver
-    > {
+    public func makeScene(input: DetailSceneInput) -> DetailViewController {
         let viewModel = DetailViewModel(
             initialDate: input.date,
             initialRecords: input.records,

--- a/FoodDiary/Presentation/Sources/Detail/DetailViewController.swift
+++ b/FoodDiary/Presentation/Sources/Detail/DetailViewController.swift
@@ -10,10 +10,7 @@ import Kingfisher
 import SnapKit
 import UIKit
 
-public final class DetailViewController<
-    RecordRepo: FoodRecordRepository,
-    PushObserver: PushNotificationObserving
->: UIViewController {
+public final class DetailViewController: UIViewController {
 
     // MARK: - Constants
 
@@ -29,7 +26,7 @@ public final class DetailViewController<
 
     // MARK: - Dependencies
 
-    private let viewModel: DetailViewModel<RecordRepo, PushObserver>
+    private let viewModel: DetailViewModel
     private let onDismissWithDate: ((Date) -> Void)?
 
     // MARK: - Flow
@@ -124,7 +121,7 @@ public final class DetailViewController<
     // MARK: - Init
 
     public init(
-        viewModel: DetailViewModel<RecordRepo, PushObserver>,
+        viewModel: DetailViewModel,
         initialScrollTarget: MealType? = nil,
         scrollToFirstRecord: Bool = true,
         shouldPopToRoot: Bool = false,
@@ -573,7 +570,7 @@ public final class DetailViewController<
     }
 
     private func resolveScrollTarget(
-        _ state: DetailViewModel<RecordRepo, PushObserver>.State
+        _ state: DetailViewModel.State
     ) -> MealType? {
         if let mealType = pendingScrollTarget {
             pendingScrollTarget = nil
@@ -585,7 +582,7 @@ public final class DetailViewController<
         return nil
     }
 
-    private func firstContentMealType(_ state: DetailViewModel<RecordRepo, PushObserver>.State)
+    private func firstContentMealType(_ state: DetailViewModel.State)
         -> MealType?
     {
         let orderedMealTypes: [MealType] = [.breakfast, .lunch, .dinner, .snack]

--- a/FoodDiary/Presentation/Sources/Detail/DetailViewModel.swift
+++ b/FoodDiary/Presentation/Sources/Detail/DetailViewModel.swift
@@ -7,10 +7,7 @@ import Combine
 import Domain
 import Foundation
 
-public final class DetailViewModel<
-    RecordRepo: FoodRecordRepository,
-    PushObserver: PushNotificationObserving
-> {
+public final class DetailViewModel {
 
     // MARK: - Output
 
@@ -41,20 +38,20 @@ public final class DetailViewModel<
 
     // MARK: - Dependencies
 
-    private let fetchRecordsUseCase: FetchFoodRecordsUseCase<RecordRepo>
-    private let saveFoodRecordUseCase: SaveFoodRecordUseCase<RecordRepo>
-    private let deleteFoodRecordUseCase: DeleteFoodRecordUseCase<RecordRepo>
-    private let pushNotificationObserver: PushObserver
+    private let fetchRecordsUseCase: FetchFoodRecordsUseCase
+    private let saveFoodRecordUseCase: SaveFoodRecordUseCase
+    private let deleteFoodRecordUseCase: DeleteFoodRecordUseCase
+    private let pushNotificationObserver: any PushNotificationObserving
 
     // MARK: - Init
 
     public init(
         initialDate: Date,
         initialRecords: [FoodRecord],
-        fetchRecordsUseCase: FetchFoodRecordsUseCase<RecordRepo>,
-        saveFoodRecordUseCase: SaveFoodRecordUseCase<RecordRepo>,
-        deleteFoodRecordUseCase: DeleteFoodRecordUseCase<RecordRepo>,
-        pushNotificationObserver: PushObserver
+        fetchRecordsUseCase: FetchFoodRecordsUseCase,
+        saveFoodRecordUseCase: SaveFoodRecordUseCase,
+        deleteFoodRecordUseCase: DeleteFoodRecordUseCase,
+        pushNotificationObserver: any PushNotificationObserving
     ) {
         self.fetchRecordsUseCase = fetchRecordsUseCase
         self.saveFoodRecordUseCase = saveFoodRecordUseCase

--- a/FoodDiary/Presentation/Sources/EditFoodRecord/Coordinator/EditCoordinator.swift
+++ b/FoodDiary/Presentation/Sources/EditFoodRecord/Coordinator/EditCoordinator.swift
@@ -32,7 +32,7 @@ public final class EditCoordinator: Coordinator {
 // MARK: - Screen Routing
 
 private extension EditCoordinator {
-    func flowBind(vc: EditFoodRecordViewController<FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>) {
+    func flowBind(vc: EditFoodRecordViewController) {
         vc.flowPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in

--- a/FoodDiary/Presentation/Sources/EditFoodRecord/Coordinator/EditSceneFactory.swift
+++ b/FoodDiary/Presentation/Sources/EditFoodRecord/Coordinator/EditSceneFactory.swift
@@ -10,22 +10,18 @@ import UIKit
 // MARK: - Factory
 
 public final class EditSceneFactory {
-    private typealias RecordRepo = FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-
-    private let updateFoodRecordUseCase: UpdateFoodRecordUseCase<RecordRepo>
-    private let deleteFoodRecordUseCase: DeleteFoodRecordUseCase<RecordRepo>
+    private let updateFoodRecordUseCase: UpdateFoodRecordUseCase
+    private let deleteFoodRecordUseCase: DeleteFoodRecordUseCase
 
     public init(
-        updateFoodRecordUseCase: UpdateFoodRecordUseCase<FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>,
-        deleteFoodRecordUseCase: DeleteFoodRecordUseCase<FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>
+        updateFoodRecordUseCase: UpdateFoodRecordUseCase,
+        deleteFoodRecordUseCase: DeleteFoodRecordUseCase
     ) {
         self.updateFoodRecordUseCase = updateFoodRecordUseCase
         self.deleteFoodRecordUseCase = deleteFoodRecordUseCase
     }
 
-    public func makeScene(input: EditSceneInput) -> EditFoodRecordViewController<
-        FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>
-    > {
+    public func makeScene(input: EditSceneInput) -> EditFoodRecordViewController {
         let viewModel = EditFoodRecordViewModel(
             record: input.record,
             updateFoodRecordUseCase: updateFoodRecordUseCase,

--- a/FoodDiary/Presentation/Sources/EditFoodRecord/EditFoodRecordViewController.swift
+++ b/FoodDiary/Presentation/Sources/EditFoodRecord/EditFoodRecordViewController.swift
@@ -22,13 +22,11 @@ private enum EditFoodRecordConstants {
     static let buttonCornerRadius: CGFloat = 25
 }
 
-public final class EditFoodRecordViewController<
-    RecordRepo: FoodRecordRepository
->: UIViewController, UIGestureRecognizerDelegate {
+public final class EditFoodRecordViewController: UIViewController, UIGestureRecognizerDelegate {
 
     // MARK: - Dependencies
 
-    private let viewModel: EditFoodRecordViewModel<RecordRepo>
+    private let viewModel: EditFoodRecordViewModel
 
     // MARK: - Flow
 
@@ -116,7 +114,7 @@ public final class EditFoodRecordViewController<
     // MARK: - Init
 
     public init(
-        viewModel: EditFoodRecordViewModel<RecordRepo>
+        viewModel: EditFoodRecordViewModel
     ) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -395,7 +393,7 @@ public final class EditFoodRecordViewController<
         }
     }
 
-    private func handleEvent(_ event: EditFoodRecordViewModel<RecordRepo>.Event) {
+    private func handleEvent(_ event: EditFoodRecordViewModel.Event) {
         switch event {
         case .saveCompleted:
             ToastView.show(type: .infoUpdate)

--- a/FoodDiary/Presentation/Sources/EditFoodRecord/EditFoodRecordViewModel.swift
+++ b/FoodDiary/Presentation/Sources/EditFoodRecord/EditFoodRecordViewModel.swift
@@ -8,7 +8,7 @@ import Domain
 import Foundation
 import UIKit
 
-public final class EditFoodRecordViewModel<RecordRepo: FoodRecordRepository> {
+public final class EditFoodRecordViewModel {
 
     // MARK: - Output
 
@@ -37,15 +37,15 @@ public final class EditFoodRecordViewModel<RecordRepo: FoodRecordRepository> {
 
     // MARK: - Dependencies
 
-    private let updateFoodRecordUseCase: UpdateFoodRecordUseCase<RecordRepo>
-    private let deleteFoodRecordUseCase: DeleteFoodRecordUseCase<RecordRepo>
+    private let updateFoodRecordUseCase: UpdateFoodRecordUseCase
+    private let deleteFoodRecordUseCase: DeleteFoodRecordUseCase
 
     // MARK: - Init
 
     public init(
         record: FoodRecord,
-        updateFoodRecordUseCase: UpdateFoodRecordUseCase<RecordRepo>,
-        deleteFoodRecordUseCase: DeleteFoodRecordUseCase<RecordRepo>
+        updateFoodRecordUseCase: UpdateFoodRecordUseCase,
+        deleteFoodRecordUseCase: DeleteFoodRecordUseCase
     ) {
         self.updateFoodRecordUseCase = updateFoodRecordUseCase
         self.deleteFoodRecordUseCase = deleteFoodRecordUseCase

--- a/FoodDiary/Presentation/Sources/ImagePicker/Coordinator/ImagePickerCoordinator.swift
+++ b/FoodDiary/Presentation/Sources/ImagePicker/Coordinator/ImagePickerCoordinator.swift
@@ -34,7 +34,7 @@ public final class ImagePickerCoordinator: Coordinator {
 // MARK: - Screen Routing
 
 private extension ImagePickerCoordinator {
-    func flowBind(vc: ImagePickerViewController<PHAsset, UIImageLoader>) {
+    func flowBind(vc: ImagePickerViewController) {
         vc.resultPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/FoodDiary/Presentation/Sources/ImagePicker/Coordinator/ImagePickerSceneFactory.swift
+++ b/FoodDiary/Presentation/Sources/ImagePicker/Coordinator/ImagePickerSceneFactory.swift
@@ -12,21 +12,21 @@ import UIKit
 
 public final class ImagePickerSceneFactory {
     private let imageProvider: UIImageLoader
-    private let fetchUseCase: FetchFoodImageAssetUseCase<FoodImageAssetFetcher<TFLiteFoodClassifier, UIImageLoader>>
+    private let fetchUseCase: FetchFoodImageAssetUseCase
 
     public init(
         imageProvider: UIImageLoader,
-        fetchUseCase: FetchFoodImageAssetUseCase<FoodImageAssetFetcher<TFLiteFoodClassifier, UIImageLoader>>
+        fetchUseCase: FetchFoodImageAssetUseCase
     ) {
         self.imageProvider = imageProvider
         self.fetchUseCase = fetchUseCase
     }
 
-    public func makeScene(input: ImagePickerSceneInput) -> ImagePickerViewController<PHAsset, UIImageLoader> {
+    public func makeScene(input: ImagePickerSceneInput) -> ImagePickerViewController {
         let date = input.date
         let fetchUseCase = self.fetchUseCase
-        
-        let fetcher: () async throws -> (photos: [PHAsset], preselectedIds: Set<String>) = {
+
+        let fetcher: () async throws -> (photos: [any ImageAssetable], preselectedIds: Set<String>) = {
             let calendar = Calendar.current
             let startOfDay = calendar.startOfDay(for: date)
             let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)!
@@ -36,7 +36,7 @@ public final class ImagePickerSceneFactory {
             let preselectedIds = Set(assets.filter { $0.foodProbability >= 0.5 }.map { $0.id })
             return (photos, preselectedIds)
         }
-        
+
         return ImagePickerViewController(
             imageProvider: imageProvider,
             configuration: .withMaxSelectionCount(10),

--- a/FoodDiary/Presentation/Sources/ImagePicker/ImagePickerResult.swift
+++ b/FoodDiary/Presentation/Sources/ImagePicker/ImagePickerResult.swift
@@ -8,9 +8,9 @@
 import Domain
 
 /// 이미지 피커 결과
-public enum ImagePickerResult<Asset: ImageAssetable> {
+public enum ImagePickerResult {
     /// 사진 선택 완료
-    case selected([Asset])
+    case selected([any ImageAssetable])
     /// 취소
     case cancelled
 }

--- a/FoodDiary/Presentation/Sources/ImagePicker/ImagePickerViewController.swift
+++ b/FoodDiary/Presentation/Sources/ImagePicker/ImagePickerViewController.swift
@@ -11,10 +11,7 @@ import UIKit
 
 // MARK: - ImagePickerViewController
 
-public final class ImagePickerViewController<
-    Asset: ImageAssetable,
-    ImageProvider: RenderableImageRepository<Asset>
->:
+public final class ImagePickerViewController:
     UIViewController, UICollectionViewDataSource, UICollectionViewDelegate,
     UICollectionViewDelegateFlowLayout
 {
@@ -50,24 +47,24 @@ public final class ImagePickerViewController<
     // MARK: - Public Publisher
 
     /// 피커 결과 Publisher
-    public var resultPublisher: AnyPublisher<ImagePickerResult<Asset>, Never> {
+    public var resultPublisher: AnyPublisher<ImagePickerResult, Never> {
         resultSubject.eraseToAnyPublisher()
     }
 
     // MARK: - Private Properties
 
-    private let resultSubject = PassthroughSubject<ImagePickerResult<Asset>, Never>()
+    private let resultSubject = PassthroughSubject<ImagePickerResult, Never>()
     private var cancellables = Set<AnyCancellable>()
 
-    private var photos: [Asset] = []
+    private var photos: [any ImageAssetable] = []
     private var preselectedFoodPhotoIds: Set<String> = []
-    private let imageProvider: ImageProvider
+    private let imageProvider: any RenderableImageRepository
     private let configuration: ImagePickerConfiguration
-    private var foodPhotos: [Asset] = []
+    private var foodPhotos: [any ImageAssetable] = []
     private var indexPathsByPhotoId: [String: [IndexPath]] = [:]
 
-    private let photosFetcher: () async throws -> (photos: [Asset], preselectedIds: Set<String>)
-    private let onSelected: (([Asset]) -> Void)?
+    private let photosFetcher: () async throws -> (photos: [any ImageAssetable], preselectedIds: Set<String>)
+    private let onSelected: (([any ImageAssetable]) -> Void)?
 
     // MARK: - State
 
@@ -75,7 +72,7 @@ public final class ImagePickerViewController<
 
     // MARK: - Computed Properties
 
-    private func photosInSection(_ section: PhotoSection) -> [Asset] {
+    private func photosInSection(_ section: PhotoSection) -> [any ImageAssetable] {
         switch section {
         case .food: return foodPhotos
         case .all: return photos
@@ -156,10 +153,10 @@ public final class ImagePickerViewController<
     // MARK: - Initialization
 
     public init(
-        imageProvider: ImageProvider,
+        imageProvider: any RenderableImageRepository,
         configuration: ImagePickerConfiguration = .default,
-        photosFetcher: @escaping () async throws -> (photos: [Asset], preselectedIds: Set<String>),
-        onSelected: (([Asset]) -> Void)? = nil
+        photosFetcher: @escaping () async throws -> (photos: [any ImageAssetable], preselectedIds: Set<String>),
+        onSelected: (([any ImageAssetable]) -> Void)? = nil
     ) {
         self.imageProvider = imageProvider
         self.configuration = configuration
@@ -218,7 +215,7 @@ public final class ImagePickerViewController<
         }
     }
 
-    private func applyPhotos(_ photos: [Asset], preselectedIds: Set<String>) {
+    private func applyPhotos(_ photos: [any ImageAssetable], preselectedIds: Set<String>) {
         self.photos = photos
         self.preselectedFoodPhotoIds = preselectedIds
         let foodPhotos = photos.filter { preselectedIds.contains($0.id) }
@@ -314,8 +311,8 @@ public final class ImagePickerViewController<
     }
 
     private static func makeIndexPathsByPhotoId(
-        allPhotos: [Asset],
-        foodPhotos: [Asset]
+        allPhotos: [any ImageAssetable],
+        foodPhotos: [any ImageAssetable]
     ) -> [String: [IndexPath]] {
         var indexPathsById: [String: [IndexPath]] = [:]
 
@@ -451,7 +448,7 @@ public final class ImagePickerViewController<
         return header
     }
 
-    private func loadImage(for photo: Asset, cell: ImagePickerCell, at indexPath: IndexPath) {
+    private func loadImage(for photo: any ImageAssetable, cell: ImagePickerCell, at indexPath: IndexPath) {
         Task {
             do {
                 let image = try await imageProvider.loadImage(

--- a/FoodDiary/Presentation/Sources/Insight/Coordinator/InsightSceneFactory.swift
+++ b/FoodDiary/Presentation/Sources/Insight/Coordinator/InsightSceneFactory.swift
@@ -8,15 +8,13 @@ import Domain
 import UIKit
 
 public final class InsightSceneFactory {
-    public typealias UseCase = FetchInsightUseCase<InsightRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>
+    private let useCase: FetchInsightUseCase
 
-    private let useCase: UseCase
-
-    public init(useCase: UseCase) {
+    public init(useCase: FetchInsightUseCase) {
         self.useCase = useCase
     }
 
-    public func makeScene() -> InsightViewController<InsightRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>> {
+    public func makeScene() -> InsightViewController {
         InsightViewController(viewModel: InsightViewModel(fetchInsightUseCase: useCase))
     }
 }

--- a/FoodDiary/Presentation/Sources/Insight/InsightViewController.swift
+++ b/FoodDiary/Presentation/Sources/Insight/InsightViewController.swift
@@ -16,7 +16,7 @@ private enum InsightConstants {
     static let contentInset: CGFloat = 20
 }
 
-public final class InsightViewController<Repo: InsightRepository>: UIViewController {
+public final class InsightViewController: UIViewController {
 
     // MARK: - UI Components
 
@@ -58,12 +58,12 @@ public final class InsightViewController<Repo: InsightRepository>: UIViewControl
 
     // MARK: - Properties
 
-    private let viewModel: InsightViewModel<Repo>
+    private let viewModel: InsightViewModel
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Init
 
-    public init(viewModel: InsightViewModel<Repo>) {
+    public init(viewModel: InsightViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }

--- a/FoodDiary/Presentation/Sources/Insight/InsightViewModel.swift
+++ b/FoodDiary/Presentation/Sources/Insight/InsightViewModel.swift
@@ -7,7 +7,7 @@ import Combine
 import Domain
 import Foundation
 
-public final class InsightViewModel<Repo: InsightRepository> {
+public final class InsightViewModel {
 
     // MARK: - Output
 
@@ -36,11 +36,11 @@ public final class InsightViewModel<Repo: InsightRepository> {
 
     // MARK: - Dependencies
 
-    private let fetchInsightUseCase: FetchInsightUseCase<Repo>
+    private let fetchInsightUseCase: FetchInsightUseCase
 
     // MARK: - Init
 
-    public init(fetchInsightUseCase: FetchInsightUseCase<Repo>) {
+    public init(fetchInsightUseCase: FetchInsightUseCase) {
         self.fetchInsightUseCase = fetchInsightUseCase
         self.stateSubject = CurrentValueSubject(State())
         setupBindings()


### PR DESCRIPTION
## ✏️ 변경 내용
- 제네릭 제거

레이어(Repository → UseCase → ViewModel → ViewController)를 제네릭으로 설계했을 때, 하위 레이어에서 결정된 구체 타입이 상위 레이어로 전파되는 문제가 지속적으로 발생함. 해당 문제를 해결하기 위한 방법으로 프로토콜을 사용하는 방법도 있었지만, 과도한 추상화가 우려되어 제거하기로 결정함!

아래와 같은 문제가 발생했었음.

```swift
struct Repository<T> { ... }
struct UseCase<T> { let repository: Repository<T> }
struct ViewModel<T> { let useCase: UseCase<T> }
class ViewController<T> { let viewModel: ViewModel<T> }
```

## ✅ 체크리스트
- [x] 빌드 정상 동작
- [x] 불필요한 파일 없음
