### PR TITLE
분석결과 푸시 2회 수신 시 앱 스토어 리뷰 요청

### DIFF
--- a/FoodDiary/App/Sources/SceneDelegate.swift
+++ b/FoodDiary/App/Sources/SceneDelegate.swift
@@ -194,6 +194,10 @@ extension SceneDelegate {
         container.register(CoachmarkStoring.self) { _ in
             CoachmarkStorage()
         }
+
+        container.register(AnalysisCountStorage.self) { _ in
+            AnalysisCountStorage()
+        }
     }
 
     fileprivate func registerDomain() {
@@ -375,6 +379,13 @@ extension SceneDelegate {
             return GetNicknameUseCase(nicknameStorage: nicknameStorage)
         }
 
+        container.register(CheckAppReviewEligibilityUseCase.self) { resolver in
+            guard let storage = resolver.resolve(AnalysisCountStorage.self) else {
+                fatalError("AnalysisCountStorage not registered")
+            }
+            return CheckAppReviewEligibilityUseCase(analysisCountStorage: storage)
+        }
+
         container.register(GetAppVersionUseCase.self) { _ in
             let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
             return GetAppVersionUseCase(appVersion: version)
@@ -523,6 +534,7 @@ extension SceneDelegate {
             let requestPhotoAuthUseCase = try? container.resolve(RequestPhotoAuthorizationUseCase<PhotoAuthorizationFetcher>.self),
             let loadWeeklyUseCase = try? container.resolve(LoadWeeklyRecordUseCase<RecordRepo, AssetFetcher>.self),
             let coachmarkStorage = try? container.resolve(CoachmarkStoring.self),
+            let checkAppReviewUseCase = try? container.resolve(CheckAppReviewEligibilityUseCase.self),
             let fetchMonthlyUseCase = try? container.resolve(FetchMonthlyCalendarDaysUseCase<RecordRepo>.self)
         else {
             fatalError("CalendarSceneFactory dependencies not registered")
@@ -537,6 +549,7 @@ extension SceneDelegate {
                 pushNotificationObserver: pushNotificationObserver,
                 getNicknameUseCase: getNicknameUseCase,
                 coachmarkStorage: coachmarkStorage,
+                checkAppReviewEligibilityUseCase: checkAppReviewUseCase,
                 fetchMonthlyCalendarDaysUseCase: fetchMonthlyUseCase,
                 fetchFoodRecordsUseCase: fetchRecordsUseCase
             ),

--- a/FoodDiary/Data/Sources/Core/Review/AnalysisCountStorage.swift
+++ b/FoodDiary/Data/Sources/Core/Review/AnalysisCountStorage.swift
@@ -1,0 +1,31 @@
+//
+//  AnalysisCountStorage.swift
+//  Data
+//
+
+import Domain
+import Foundation
+
+public struct AnalysisCountStorage: AnalysisCountStoring {
+    private let countKey = "analysis_push_count"
+    private let reviewRequestedKey = "app_review_requested"
+
+    public init() {}
+
+    public func getCount() -> Int {
+        UserDefaults.standard.integer(forKey: countKey)
+    }
+
+    public func incrementCount() {
+        let current = getCount()
+        UserDefaults.standard.set(current + 1, forKey: countKey)
+    }
+
+    public func hasRequestedReview() -> Bool {
+        UserDefaults.standard.bool(forKey: reviewRequestedKey)
+    }
+
+    public func setReviewRequested() {
+        UserDefaults.standard.set(true, forKey: reviewRequestedKey)
+    }
+}

--- a/FoodDiary/Domain/Sources/Core/Review/AnalysisCountStoring.swift
+++ b/FoodDiary/Domain/Sources/Core/Review/AnalysisCountStoring.swift
@@ -1,0 +1,13 @@
+//
+//  AnalysisCountStoring.swift
+//  Domain
+//
+
+import Foundation
+
+public protocol AnalysisCountStoring {
+    func getCount() -> Int
+    func incrementCount()
+    func hasRequestedReview() -> Bool
+    func setReviewRequested()
+}

--- a/FoodDiary/Domain/Sources/UseCase/CheckAppReviewEligibilityUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/CheckAppReviewEligibilityUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  CheckAppReviewEligibilityUseCase.swift
+//  Domain
+//
+
+import Foundation
+
+public struct CheckAppReviewEligibilityUseCase {
+    private let analysisCountStorage: AnalysisCountStoring
+    private let requiredCount: Int
+
+    public init(
+        analysisCountStorage: AnalysisCountStoring,
+        requiredCount: Int = 2
+    ) {
+        self.analysisCountStorage = analysisCountStorage
+        self.requiredCount = requiredCount
+    }
+
+    /// 카운트를 증가시키고, 리뷰 요청 조건 충족 여부를 반환
+    public func execute() -> Bool {
+        guard !analysisCountStorage.hasRequestedReview() else { return false }
+        analysisCountStorage.incrementCount()
+        if analysisCountStorage.getCount() >= requiredCount {
+            analysisCountStorage.setReviewRequested()
+            return true
+        }
+        return false
+    }
+}

--- a/FoodDiary/Presentation/Sources/Calendar/Coordinator/CalendarSceneFactory.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/Coordinator/CalendarSceneFactory.swift
@@ -17,6 +17,7 @@ public final class CalendarSceneFactory {
     private let pushNotificationObserver: PushNotificationObserver
     private let getNicknameUseCase: GetNicknameUseCase
     private let coachmarkStorage: any CoachmarkStoring
+    private let checkAppReviewEligibilityUseCase: CheckAppReviewEligibilityUseCase
     private let fetchMonthlyCalendarDaysUseCase: FetchMonthlyCalendarDaysUseCase<RecordRepo>
     private let fetchFoodRecordsUseCase: FetchFoodRecordsUseCase<RecordRepo>
 
@@ -30,6 +31,7 @@ public final class CalendarSceneFactory {
         pushNotificationObserver: PushNotificationObserver,
         getNicknameUseCase: GetNicknameUseCase,
         coachmarkStorage: any CoachmarkStoring,
+        checkAppReviewEligibilityUseCase: CheckAppReviewEligibilityUseCase,
         fetchMonthlyCalendarDaysUseCase: FetchMonthlyCalendarDaysUseCase<FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>,
         fetchFoodRecordsUseCase: FetchFoodRecordsUseCase<FoodRecordRepositoryImpl<HTTPClient, AuthTokenStorage<KeychainService>>>
     ) {
@@ -39,6 +41,7 @@ public final class CalendarSceneFactory {
         self.pushNotificationObserver = pushNotificationObserver
         self.getNicknameUseCase = getNicknameUseCase
         self.coachmarkStorage = coachmarkStorage
+        self.checkAppReviewEligibilityUseCase = checkAppReviewEligibilityUseCase
         self.fetchMonthlyCalendarDaysUseCase = fetchMonthlyCalendarDaysUseCase
         self.fetchFoodRecordsUseCase = fetchFoodRecordsUseCase
     }
@@ -50,7 +53,8 @@ public final class CalendarSceneFactory {
             saveFoodRecordUseCase: saveFoodRecordUseCase,
             pushNotificationObserver: pushNotificationObserver,
             getNicknameUseCase: getNicknameUseCase,
-            coachmarkStorage: coachmarkStorage
+            coachmarkStorage: coachmarkStorage,
+            checkAppReviewEligibilityUseCase: checkAppReviewEligibilityUseCase
         )
         let monthlyVM = MonthlyCalendarViewModel(
             fetchMonthlyCalendarDaysUseCase: fetchMonthlyCalendarDaysUseCase,

--- a/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/ViewModel/WeeklyCalendarViewModel.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/ViewModel/WeeklyCalendarViewModel.swift
@@ -51,6 +51,7 @@ public final class WeeklyCalendarViewModel<
     private let pushNotificationObserver: PushObserver
     private let getNicknameUseCase: GetNicknameUseCase
     private let coachmarkStorage: any CoachmarkStoring
+    private let checkAppReviewEligibilityUseCase: CheckAppReviewEligibilityUseCase
 
     // MARK: - Init
 
@@ -60,7 +61,8 @@ public final class WeeklyCalendarViewModel<
         saveFoodRecordUseCase: SaveFoodRecordUseCase<RecordRepo>,
         pushNotificationObserver: PushObserver,
         getNicknameUseCase: GetNicknameUseCase,
-        coachmarkStorage: any CoachmarkStoring
+        coachmarkStorage: any CoachmarkStoring,
+        checkAppReviewEligibilityUseCase: CheckAppReviewEligibilityUseCase
     ) {
         self.requestPhotoAuthorizationUseCase = requestPhotoAuthorizationUseCase
         self.loadWeeklyCalendarDataUseCase = loadWeeklyCalendarDataUseCase
@@ -68,6 +70,7 @@ public final class WeeklyCalendarViewModel<
         self.pushNotificationObserver = pushNotificationObserver
         self.getNicknameUseCase = getNicknameUseCase
         self.coachmarkStorage = coachmarkStorage
+        self.checkAppReviewEligibilityUseCase = checkAppReviewEligibilityUseCase
 
         let cal = Calendar.current
         self.calendar = cal
@@ -305,6 +308,10 @@ public final class WeeklyCalendarViewModel<
         if notificationDate == selectedDate {
             await updateDateContent(for: state.selectedDate)
         }
+
+        if checkAppReviewEligibilityUseCase.execute() {
+            eventSubject.send(.requestAppReview)
+        }
     }
 }
 
@@ -342,6 +349,7 @@ extension WeeklyCalendarViewModel {
         case uploadCompleted(date: Date, mealType: MealType)
         case saveFailed(Error)
         case loadFailed(Error)
+        case requestAppReview
     }
 }
 

--- a/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/WeeklyCalendarViewController.swift
+++ b/FoodDiary/Presentation/Sources/Calendar/WeeklyCalendar/WeeklyCalendarViewController.swift
@@ -8,6 +8,7 @@ import Data
 import DesignSystem
 import Domain
 import SnapKit
+import StoreKit
 import UIKit
 
 private enum Constants {
@@ -247,6 +248,8 @@ public final class WeeklyCalendarViewController<
                     self?.showSaveErrorAlert(error)
                 case .loadFailed(let error):
                     self?.showLoadErrorAlert(error)
+                case .requestAppReview:
+                    self?.requestAppReview()
                 }
             }
             .store(in: &cancellables)
@@ -345,6 +348,11 @@ public final class WeeklyCalendarViewController<
         )
         alert.addAction(UIAlertAction(title: "확인", style: .default))
         present(alert, animated: true)
+    }
+
+    private func requestAppReview() {
+        guard let windowScene = view.window?.windowScene else { return }
+        AppStore.requestReview(in: windowScene)
     }
 }
 


### PR DESCRIPTION
## Summary
- 분석결과 푸시 알림을 누적 2회 수신했을 때 `AppStore.requestReview(in:)`으로 앱 스토어 리뷰를 요청합니다
- 리뷰 요청은 앱 생애주기에서 1회만 시도하며, UserDefaults로 카운트와 요청 여부를 영구 저장합니다
- Clean Architecture 패턴에 맞춰 Domain(프로토콜+UseCase) → Data(구현체) → Presentation(이벤트) 순서로 구현했습니다

## Changes
- `AnalysisCountStoring` 프로토콜 (Domain)
- `AnalysisCountStorage` UserDefaults 구현체 (Data)
- `CheckAppReviewEligibilityUseCase` 카운트 증가 + 리뷰 조건 판단 (Domain)
- `WeeklyCalendarViewModel.handlePushNotification`에서 리뷰 조건 확인 후 `.requestAppReview` 이벤트 발행
- `WeeklyCalendarViewController`에서 `AppStore.requestReview(in:)` 호출

## Test plan
- [ ] UserDefaults의 `analysis_push_count`를 1로 설정 후 분석결과 푸시 1회 수신 → 리뷰 다이얼로그 표시 확인
- [ ] `app_review_requested`가 true인 상태에서 추가 푸시 수신 → 리뷰 요청 안 되는 것 확인
- [ ] 앱 재시작 후에도 카운트가 유지되는지 확인