### PR TITLE
로컬 푸시 구현

### DIFF
--- a/FoodDiary/App/Sources/AppDelegate.swift
+++ b/FoodDiary/App/Sources/AppDelegate.swift
@@ -141,8 +141,10 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     ) {
         let userInfo = response.notification.request.content.userInfo
 
-        if userInfo["is_local_notification"] as? Bool == true {
-            // 로컬 알림 탭 → 딥링크로 상세 화면 이동
+        if userInfo["notification_type"] as? String == "daily_reminder" {
+            // 매일 리마인더 탭 → 앱이 열리는 기본 동작만 수행
+        } else if userInfo["is_local_notification"] as? Bool == true {
+            // 분석 완료 로컬 알림 탭 → 딥링크로 상세 화면 이동
             if let diaryDate = userInfo["diary_date"] as? String {
                 NotificationCenter.default.post(
                     name: AppNotification.Push.deepLinkToDetail,
@@ -164,8 +166,11 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     ) {
         let userInfo = notification.request.content.userInfo
 
-        if userInfo["is_local_notification"] as? Bool == true {
-            // 로컬 알림이 포그라운드에서 도착 → 배너 표시 안 함 (토스트로 이미 처리됨)
+        if userInfo["notification_type"] as? String == "daily_reminder" {
+            // 매일 리마인더가 포그라운드에 도착 → 배너 표시 안 함 (이미 앱 사용 중)
+            completionHandler([])
+        } else if userInfo["is_local_notification"] as? Bool == true {
+            // 분석 완료 로컬 알림이 포그라운드에서 도착 → 배너 표시 안 함 (토스트로 이미 처리됨)
             completionHandler([])
         } else {
             handlePushNotification(userInfo)

--- a/FoodDiary/App/Sources/AppFlowController.swift
+++ b/FoodDiary/App/Sources/AppFlowController.swift
@@ -54,6 +54,16 @@ final class AppFlowController: UIViewController, SceneTransitioning {
         setupAnalysisCompletionToast()
         setupDeepLinkHandling()
         setupLoginSessionObservation()
+        setupForegroundReminderScheduling()
+    }
+
+    private func setupForegroundReminderScheduling() {
+        NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.tryScheduleDailyReminder()
+            }
+            .store(in: &cancellables)
     }
 
     private func setupLoginSessionObservation() {
@@ -213,6 +223,7 @@ extension AppFlowController {
             switch settings.authorizationStatus {
             case .authorized, .provisional, .ephemeral:
                 UIApplication.shared.registerForRemoteNotifications()
+                tryScheduleDailyReminder()
             case .notDetermined:
                 await requestSystemNotificationAuthorization()
             case .denied:
@@ -231,9 +242,15 @@ extension AppFlowController {
             )
             guard granted else { return }
             UIApplication.shared.registerForRemoteNotifications()
+            tryScheduleDailyReminder()
         } catch {
             print("알림 권한 요청 실패: \(error)")
         }
+    }
+
+    fileprivate func tryScheduleDailyReminder() {
+        guard let useCase = try? container.resolve(ScheduleDailyReminderUseCase.self) else { return }
+        Task { await useCase.execute() }
     }
 
     fileprivate func validateToken() async -> Bool {

--- a/FoodDiary/App/Sources/SceneDelegate.swift
+++ b/FoodDiary/App/Sources/SceneDelegate.swift
@@ -51,6 +51,10 @@ extension SceneDelegate {
             NotificationAuthorizationProvider()
         }
 
+        container.register(LocalNotificationScheduling.self) { _ in
+            LocalNotificationScheduler()
+        }
+
         container.register(KeychainService.self) { _ in
             KeychainService()
         }
@@ -465,6 +469,14 @@ extension SceneDelegate {
                 deviceID: deviceID,
                 osVersion: osVersion
             )
+        }
+
+        container.register(ScheduleDailyReminderUseCase.self) { resolver in
+            guard let scheduler = resolver.resolve(LocalNotificationScheduling.self),
+                  let provider = resolver.resolve(NotificationAuthorizationProviding.self) else {
+                fatalError("ScheduleDailyReminderUseCase dependencies not registered")
+            }
+            return ScheduleDailyReminderUseCase(scheduler: scheduler, authorizationProvider: provider)
         }
     }
 

--- a/FoodDiary/Data/Sources/Core/Notification/LocalNotificationScheduler.swift
+++ b/FoodDiary/Data/Sources/Core/Notification/LocalNotificationScheduler.swift
@@ -1,0 +1,62 @@
+//
+//  LocalNotificationScheduler.swift
+//  Data
+//
+
+import UserNotifications
+import Domain
+
+/// 테스트 가능성을 위한 내부 추상화. 실제 구현은 UNUserNotificationCenter
+protocol UserNotificationCentering: Sendable {
+    func add(_ request: UNNotificationRequest) async throws
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String])
+}
+
+extension UNUserNotificationCenter: UserNotificationCentering {}
+
+public final class LocalNotificationScheduler: LocalNotificationScheduling {
+    static let dailyReminderIdentifier = "daily_reminder"
+
+    private let notificationCenter: any UserNotificationCentering
+
+    public convenience init() {
+        self.init(notificationCenter: UNUserNotificationCenter.current())
+    }
+
+    init(notificationCenter: any UserNotificationCentering) {
+        self.notificationCenter = notificationCenter
+    }
+
+    public func scheduleDailyReminder(hour: Int, minute: Int) async {
+        let content = UNMutableNotificationContent()
+        content.title = "오늘 먹은 음식, 기록해볼까요?"
+        content.body = "하루가 끝나기 전에 오늘의 식사를 남겨보세요."
+        content.sound = .default
+        content.userInfo = ["notification_type": "daily_reminder"]
+
+        var dateComponents = DateComponents()
+        dateComponents.hour = hour
+        dateComponents.minute = minute
+
+        let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+
+        notificationCenter.removePendingNotificationRequests(
+            withIdentifiers: [Self.dailyReminderIdentifier]
+        )
+
+        let request = UNNotificationRequest(
+            identifier: Self.dailyReminderIdentifier,
+            content: content,
+            trigger: trigger
+        )
+        try? await notificationCenter.add(request)
+        print("[LocalNotification] 매일 \(hour):\(String(format: "%02d", minute)) 리마인더 등록 완료")
+    }
+
+    public func cancelDailyReminder() async {
+        notificationCenter.removePendingNotificationRequests(
+            withIdentifiers: [Self.dailyReminderIdentifier]
+        )
+        print("[LocalNotification] 매일 리마인더 취소 완료")
+    }
+}

--- a/FoodDiary/Data/Tests/LocalNotificationSchedulerTests.swift
+++ b/FoodDiary/Data/Tests/LocalNotificationSchedulerTests.swift
@@ -1,0 +1,71 @@
+//
+//  LocalNotificationSchedulerTests.swift
+//  Data
+//
+
+@testable import Data
+import Foundation
+import Testing
+import UserNotifications
+
+@Suite("LocalNotificationScheduler Tests")
+struct LocalNotificationSchedulerTests {
+
+    @Test("scheduleDailyReminder는 21:00 매일 반복되는 캘린더 트리거를 등록한다")
+    func scheduleDailyReminder_addsCalendarTriggerAt21WithRepeats() async throws {
+        let center = MockUserNotificationCenter()
+        let sut = LocalNotificationScheduler(notificationCenter: center)
+
+        await sut.scheduleDailyReminder(hour: 21, minute: 0)
+
+        // 동일 identifier에 대해 기존 pending 제거 후 새로 add 되었는지
+        #expect(center.removedIdentifiers.count == 1)
+        #expect(center.removedIdentifiers.first == [LocalNotificationScheduler.dailyReminderIdentifier])
+
+        #expect(center.addedRequests.count == 1)
+        let request = try #require(center.addedRequests.first)
+
+        #expect(request.identifier == LocalNotificationScheduler.dailyReminderIdentifier)
+
+        // 매일 반복되는 캘린더 트리거인지
+        let trigger = try #require(request.trigger as? UNCalendarNotificationTrigger)
+        #expect(trigger.repeats == true)
+        #expect(trigger.dateComponents.hour == 21)
+        #expect(trigger.dateComponents.minute == 0)
+
+        // 컨텐츠 검증 — 알림이 실제로 표시될 때 사용자가 보는 부분
+        #expect(request.content.title == "오늘 먹은 음식, 기록해볼까요?")
+        #expect(request.content.body == "하루가 끝나기 전에 오늘의 식사를 남겨보세요.")
+        #expect(request.content.sound == .default)
+        #expect(request.content.userInfo["notification_type"] as? String == "daily_reminder")
+        // 분석 결과 푸시 분기와의 충돌 방지: is_local_notification 키는 들어가면 안 됨
+        #expect(request.content.userInfo["is_local_notification"] == nil)
+    }
+
+    @Test("cancelDailyReminder는 등록된 리마인더를 제거하고 새로 추가하지 않는다")
+    func cancelDailyReminder_removesPendingRequestsWithoutAdding() async {
+        let center = MockUserNotificationCenter()
+        let sut = LocalNotificationScheduler(notificationCenter: center)
+
+        await sut.cancelDailyReminder()
+
+        #expect(center.removedIdentifiers.count == 1)
+        #expect(center.removedIdentifiers.first == [LocalNotificationScheduler.dailyReminderIdentifier])
+        #expect(center.addedRequests.isEmpty)
+    }
+
+    @Test("scheduleDailyReminder를 두 번 호출해도 동일 identifier로 덮어쓰기된다 (idempotent)")
+    func scheduleDailyReminder_calledTwice_isIdempotent() async {
+        let center = MockUserNotificationCenter()
+        let sut = LocalNotificationScheduler(notificationCenter: center)
+
+        await sut.scheduleDailyReminder(hour: 21, minute: 0)
+        await sut.scheduleDailyReminder(hour: 21, minute: 0)
+
+        #expect(center.removedIdentifiers.count == 2)
+        #expect(center.addedRequests.count == 2)
+        #expect(center.addedRequests.allSatisfy {
+            $0.identifier == LocalNotificationScheduler.dailyReminderIdentifier
+        })
+    }
+}

--- a/FoodDiary/Data/Tests/Mock/MockUserNotificationCenter.swift
+++ b/FoodDiary/Data/Tests/Mock/MockUserNotificationCenter.swift
@@ -1,0 +1,24 @@
+//
+//  MockUserNotificationCenter.swift
+//  Data
+//
+
+@testable import Data
+import UserNotifications
+
+final class MockUserNotificationCenter: UserNotificationCentering, @unchecked Sendable {
+    private(set) var addedRequests: [UNNotificationRequest] = []
+    private(set) var removedIdentifiers: [[String]] = []
+    var addError: Error?
+
+    func add(_ request: UNNotificationRequest) async throws {
+        if let addError {
+            throw addError
+        }
+        addedRequests.append(request)
+    }
+
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+        removedIdentifiers.append(identifiers)
+    }
+}

--- a/FoodDiary/Domain/Sources/Core/Notification/LocalNotificationScheduling.swift
+++ b/FoodDiary/Domain/Sources/Core/Notification/LocalNotificationScheduling.swift
@@ -1,0 +1,11 @@
+//
+//  LocalNotificationScheduling.swift
+//  Domain
+//
+
+import Foundation
+
+public protocol LocalNotificationScheduling: Sendable {
+    func scheduleDailyReminder(hour: Int, minute: Int) async
+    func cancelDailyReminder() async
+}

--- a/FoodDiary/Domain/Sources/UseCase/ScheduleDailyReminderUseCase.swift
+++ b/FoodDiary/Domain/Sources/UseCase/ScheduleDailyReminderUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  ScheduleDailyReminderUseCase.swift
+//  Domain
+//
+
+import Foundation
+
+public struct ScheduleDailyReminderUseCase: Sendable {
+    private let scheduler: any LocalNotificationScheduling
+    private let authorizationProvider: any NotificationAuthorizationProviding
+
+    public init(
+        scheduler: any LocalNotificationScheduling,
+        authorizationProvider: any NotificationAuthorizationProviding
+    ) {
+        self.scheduler = scheduler
+        self.authorizationProvider = authorizationProvider
+    }
+
+    public func execute() async {
+        if await authorizationProvider.isNotificationEnabled() {
+            await scheduler.scheduleDailyReminder(hour: 21, minute: 0)
+        } else {
+            await scheduler.cancelDailyReminder()
+        }
+    }
+}

--- a/FoodDiary/Domain/Tests/Mock/MockLocalNotificationScheduler.swift
+++ b/FoodDiary/Domain/Tests/Mock/MockLocalNotificationScheduler.swift
@@ -1,0 +1,24 @@
+//
+//  MockLocalNotificationScheduler.swift
+//  Domain
+//
+
+@testable import Domain
+import Foundation
+
+final class MockLocalNotificationScheduler: LocalNotificationScheduling, @unchecked Sendable {
+    private(set) var scheduleCallCount = 0
+    private(set) var cancelCallCount = 0
+    private(set) var lastScheduledHour: Int?
+    private(set) var lastScheduledMinute: Int?
+
+    func scheduleDailyReminder(hour: Int, minute: Int) async {
+        scheduleCallCount += 1
+        lastScheduledHour = hour
+        lastScheduledMinute = minute
+    }
+
+    func cancelDailyReminder() async {
+        cancelCallCount += 1
+    }
+}

--- a/FoodDiary/Domain/Tests/Mock/MockNotificationAuthorizationProvider.swift
+++ b/FoodDiary/Domain/Tests/Mock/MockNotificationAuthorizationProvider.swift
@@ -1,0 +1,15 @@
+//
+//  MockNotificationAuthorizationProvider.swift
+//  Domain
+//
+
+@testable import Domain
+import Foundation
+
+final class MockNotificationAuthorizationProvider: NotificationAuthorizationProviding, @unchecked Sendable {
+    var isEnabledToReturn: Bool = true
+
+    func isNotificationEnabled() async -> Bool {
+        isEnabledToReturn
+    }
+}

--- a/FoodDiary/Domain/Tests/ScheduleDailyReminderUseCaseTests.swift
+++ b/FoodDiary/Domain/Tests/ScheduleDailyReminderUseCaseTests.swift
@@ -1,0 +1,50 @@
+//
+//  ScheduleDailyReminderUseCaseTests.swift
+//  Domain
+//
+
+@testable import Domain
+import Foundation
+import Testing
+
+@Suite("ScheduleDailyReminderUseCase Tests")
+struct ScheduleDailyReminderUseCaseTests {
+
+    @Test("알림 권한이 켜져 있으면 매일 21:00 리마인더가 등록된다")
+    func whenAuthorizationEnabled_schedulesDailyReminderAt21() async {
+        let scheduler = MockLocalNotificationScheduler()
+        let authProvider = MockNotificationAuthorizationProvider()
+        authProvider.isEnabledToReturn = true
+
+        let sut = ScheduleDailyReminderUseCase(
+            scheduler: scheduler,
+            authorizationProvider: authProvider
+        )
+
+        await sut.execute()
+
+        #expect(scheduler.scheduleCallCount == 1)
+        #expect(scheduler.cancelCallCount == 0)
+        #expect(scheduler.lastScheduledHour == 21)
+        #expect(scheduler.lastScheduledMinute == 0)
+    }
+
+    @Test("알림 권한이 꺼져 있으면 리마인더가 등록되지 않고 취소된다")
+    func whenAuthorizationDisabled_cancelsReminderInsteadOfScheduling() async {
+        let scheduler = MockLocalNotificationScheduler()
+        let authProvider = MockNotificationAuthorizationProvider()
+        authProvider.isEnabledToReturn = false
+
+        let sut = ScheduleDailyReminderUseCase(
+            scheduler: scheduler,
+            authorizationProvider: authProvider
+        )
+
+        await sut.execute()
+
+        #expect(scheduler.scheduleCallCount == 0)
+        #expect(scheduler.cancelCallCount == 1)
+        #expect(scheduler.lastScheduledHour == nil)
+        #expect(scheduler.lastScheduledMinute == nil)
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
@@ -30,7 +30,7 @@ extension InfoPlist {
                     "UIImageName": "",
                 ],
                 "NSPhotoLibraryUsageDescription": "음식 사진을 분류하기 위해 사진 라이브러리 접근 권한이 필요합니다.",
-                "NSUserNotificationsUsageDescription": "AI 분석 완료 알림을 받기 위해선 알림 권한이 필요합니다.",
+                "NSUserNotificationsUsageDescription": "AI 분석 완료 및 매일 식단 기록 리마인더 알림을 받기 위해선 알림 권한이 필요합니다.",
                 "BASE_URL": "$(BASE_URL)",
                 "SENTRY_DSN": "$(SENTRY_DSN)",
                 "NSAppTransportSecurity": [


### PR DESCRIPTION
## Summary

매일 저녁 21:00에 식단 기록을 유도하는 로컬 푸시 알림(daily reminder) 기능을 추가합니다.
알림 권한 상태에 따라 자동으로 등록/취소되며, 기존 분석 완료 푸시와의 충돌 없이 분리 처리됩니다.

## 작업 내용

- 매일 21:00 식단 기록 리마인더 로컬 푸시 등록 기능 추가
- 알림 권한 ON이면 등록, OFF면 취소 (포그라운드 진입 시 권한 상태 재평가)
- 분석 완료 로컬 알림(`is_local_notification`)과 매일 리마인더(`daily_reminder`) 알림 분기 분리
- `LocalNotificationScheduler`, `ScheduleDailyReminderUseCase` 단위 테스트 추가

## 변경 파일

| 레이어 | 파일 | 변경 |
|---|---|---|
| Domain | `LocalNotificationScheduling.swift` | 신규 — 로컬 알림 스케줄링 프로토콜 |
| Domain | `ScheduleDailyReminderUseCase.swift` | 신규 — 권한 확인 후 등록/취소 UseCase |
| Data | `LocalNotificationScheduler.swift` | 신규 — `UNCalendarNotificationTrigger` 기반 구현 |
| App | `SceneDelegate.swift` | 수정 — `LocalNotificationScheduling`, `ScheduleDailyReminderUseCase` DI 등록 |
| App | `AppFlowController.swift` | 수정 — 권한 승인 직후 / 포그라운드 진입 시 `tryScheduleDailyReminder()` 호출 |
| App | `AppDelegate.swift` | 수정 — `daily_reminder` 알림 분기 추가, 포그라운드 배너 미표시 |
| Tuist | `InfoPlist+Templates.swift` | 수정 — `NSUserNotificationsUsageDescription` 문구 업데이트 |
| Test (Domain) | `ScheduleDailyReminderUseCaseTests.swift` | 신규 |
| Test (Domain) | `Mock/MockLocalNotificationScheduler.swift` | 신규 |
| Test (Domain) | `Mock/MockNotificationAuthorizationProvider.swift` | 신규 |
| Test (Data) | `LocalNotificationSchedulerTests.swift` | 신규 |
| Test (Data) | `Mock/MockUserNotificationCenter.swift` | 신규 |

## 아키텍처

Clean Architecture 의존성 방향을 준수합니다: `Domain ← Data ← App`

```
App (AppFlowController)
 └─ ScheduleDailyReminderUseCase  ← Domain
      ├─ LocalNotificationScheduling  ← Domain (protocol)
      │    └─ LocalNotificationScheduler  ← Data (impl)
      └─ NotificationAuthorizationProviding  ← Domain (protocol, 기존)
```

- Domain은 `LocalNotificationScheduling` 프로토콜만 노출, `UserNotifications` 프레임워크 의존 없음
- Data의 `LocalNotificationScheduler`는 내부 `UserNotificationCentering` 추상화를 통해 `UNUserNotificationCenter`를 분리, 테스트에서 Mock으로 교체 가능
- DI는 `SceneDelegate`에서 등록, `AppFlowController`에서 resolve

## 동작 흐름

```
앱 실행 / 포그라운드 복귀
    └─ AppFlowController.tryScheduleDailyReminder()
            └─ ScheduleDailyReminderUseCase.execute()
                    ├─ 권한 ON  → scheduleDailyReminder(hour: 21, minute: 0)
                    │             (동일 identifier 덮어쓰기 — idempotent)
                    └─ 권한 OFF → cancelDailyReminder()

알림 탭 (UNUserNotificationCenter delegate)
    ├─ notification_type == "daily_reminder"  → 앱 열기만 수행, 딥링크 없음
    └─ is_local_notification == true          → 기존 분석 결과 딥링크 처리 유지
```

## 테스트 플랜

- [x] `tuist test` — Data, Domain 테스트 통과 확인
- [x] 시뮬레이터: 알림 권한 허용 후 pending notification 목록에 `daily_reminder` identifier 확인
- [x] 시뮬레이터: 권한 거부 상태로 포그라운드 진입 시 리마인더 취소 확인
- [x] 분석 완료 로컬 알림 탭 시 딥링크 정상 동작 확인 (daily_reminder와 혼용 없음)
- [x] 매일 리마인더 탭 시 앱만 열리고 딥링크 미실행 확인
